### PR TITLE
allow passing fetch options to every API endpoint

### DIFF
--- a/src/api/_osmFetch.ts
+++ b/src/api/_osmFetch.ts
@@ -2,6 +2,12 @@ import { getAuthToken } from "../auth";
 import { getConfig } from "../config";
 import { xmlParser } from "./_xml";
 
+/**
+ * extra options that are passed to {@link fetch}. Use this to
+ * customise HTTP headers or pass an {@link AbortSignal}.
+ */
+export type FetchOptions = Omit<RequestInit, "method" | "body">;
+
 const toBase64 = (text: string): string => {
   if (typeof btoa === "undefined") {
     return Buffer.from(text, "binary").toString("base64");
@@ -13,8 +19,8 @@ const toBase64 = (text: string): string => {
 export async function osmFetch<T>(
   path: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  qsObject?: Record<string, any>,
-  fetchOptions?: RequestInit
+  qsObject: Record<string, any> | undefined,
+  fetchOptions: RequestInit | undefined
 ): Promise<T> {
   const { apiUrl, authHeader, basicAuth, userAgent } = getConfig();
 

--- a/src/api/changesets/createChangesetComment.ts
+++ b/src/api/changesets/createChangesetComment.ts
@@ -1,14 +1,17 @@
-import { osmFetch } from "../_osmFetch";
+import { type FetchOptions, osmFetch } from "../_osmFetch";
 
 /** Add a comment to a changeset. The changeset must be closed. */
 export async function createChangesetComment(
   changesetId: number,
-  commentText: string
+  commentText: string,
+  options?: FetchOptions
 ): Promise<void> {
   await osmFetch(`/0.6/changeset/${changesetId}/comment`, undefined, {
+    ...options,
     method: "POST",
     body: `text=${encodeURIComponent(commentText)}`,
     headers: {
+      ...options?.headers,
       "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
     },
   });

--- a/src/api/changesets/getChangesetDiff.ts
+++ b/src/api/changesets/getChangesetDiff.ts
@@ -1,11 +1,18 @@
 import type { OsmChange } from "../../types";
-import { osmFetch } from "../_osmFetch";
+import { type FetchOptions, osmFetch } from "../_osmFetch";
 import type { RawOsmChange } from "../_rawResponse";
 import { parseOsmChangeJson } from "./_parseOsmChangeXml";
 
 /** gets the osmChange file for a changeset */
-export async function getChangesetDiff(id: number): Promise<OsmChange> {
-  const raw = await osmFetch<RawOsmChange>(`/0.6/changeset/${id}/download`);
+export async function getChangesetDiff(
+  id: number,
+  options?: FetchOptions
+): Promise<OsmChange> {
+  const raw = await osmFetch<RawOsmChange>(
+    `/0.6/changeset/${id}/download`,
+    undefined,
+    options
+  );
 
   return parseOsmChangeJson(raw);
 }

--- a/src/api/changesets/getChangesets.ts
+++ b/src/api/changesets/getChangesets.ts
@@ -1,5 +1,5 @@
 import type { BBox, Changeset } from "../../types";
-import { osmFetch } from "../_osmFetch";
+import { type FetchOptions, osmFetch } from "../_osmFetch";
 import type { RawChangeset } from "../_rawResponse";
 
 const mapRawChangeset = ({ comments, ...raw }: RawChangeset): Changeset => ({
@@ -47,16 +47,18 @@ export type ListChangesetOptions = {
  * Returns at most 100 changesets.
  */
 export async function listChangesets(
-  options: ListChangesetOptions
+  query: ListChangesetOptions,
+  options?: FetchOptions
 ): Promise<Changeset[]> {
-  const { only, ...otherOptions } = options;
+  const { only, ...otherQueries } = query;
 
   const raw = await osmFetch<{ changesets: RawChangeset[] }>(
     "/0.6/changesets.json",
     {
       ...(only && { [only]: true }),
-      ...otherOptions,
-    }
+      ...otherQueries,
+    },
+    options
   );
 
   return raw.changesets.map(mapRawChangeset);
@@ -65,11 +67,14 @@ export async function listChangesets(
 /** get a single changeset */
 export async function getChangeset(
   id: number,
-  includeDiscussion = true
+  // eslint-disable-next-line default-param-last
+  includeDiscussion = true,
+  options?: FetchOptions
 ): Promise<Changeset> {
   const raw = await osmFetch<{ changeset: RawChangeset }>(
     `/0.6/changeset/${id}.json`,
-    includeDiscussion ? { include_discussion: 1 } : {}
+    includeDiscussion ? { include_discussion: 1 } : {},
+    options
   );
 
   return mapRawChangeset(raw.changeset);

--- a/src/api/changesets/subscription.ts
+++ b/src/api/changesets/subscription.ts
@@ -1,19 +1,23 @@
-import { osmFetch } from "../_osmFetch";
+import { type FetchOptions, osmFetch } from "../_osmFetch";
 
-export async function subscribeToChangeset(changesetId: number): Promise<void> {
+export async function subscribeToChangeset(
+  changesetId: number,
+  options?: FetchOptions
+): Promise<void> {
   await osmFetch(
     `/0.6/changeset/${changesetId}/subscribe`,
     {},
-    { method: "POST" }
+    { ...options, method: "POST" }
   );
 }
 
 export async function unsubscribeFromChangeset(
-  changesetId: number
+  changesetId: number,
+  options?: FetchOptions
 ): Promise<void> {
   await osmFetch(
     `/0.6/changeset/${changesetId}/unsubscribe`,
     {},
-    { method: "POST" }
+    { ...options, method: "POST" }
   );
 }

--- a/src/api/getCapabilities.ts
+++ b/src/api/getCapabilities.ts
@@ -1,4 +1,4 @@
-import { osmFetch } from "./_osmFetch";
+import { type FetchOptions, osmFetch } from "./_osmFetch";
 
 export type ApiStatus = "online" | "offline";
 
@@ -54,8 +54,10 @@ export type ApiCapabilities = {
 };
 
 /** This API provides information about the capabilities and limitations of the current API. */
-export async function getApiCapabilities(): Promise<ApiCapabilities> {
-  return osmFetch<ApiCapabilities>("/capabilities.json");
+export async function getApiCapabilities(
+  options?: FetchOptions
+): Promise<ApiCapabilities> {
+  return osmFetch<ApiCapabilities>("/capabilities.json", undefined, options);
 }
 
 // ---------------------------------------------------------------------- //

--- a/src/api/getFeature.ts
+++ b/src/api/getFeature.ts
@@ -5,7 +5,7 @@ import type {
   OsmWay,
   UtilFeatureForType,
 } from "../types";
-import { osmFetch } from "./_osmFetch";
+import { type FetchOptions, osmFetch } from "./_osmFetch";
 
 /**
  * Gets infomation about a node, way, or relation.
@@ -18,7 +18,8 @@ import { osmFetch } from "./_osmFetch";
 export async function getFeature<T extends OsmFeatureType>(
   type: T,
   id: number,
-  full?: false
+  full?: false,
+  options?: FetchOptions
 ): Promise<[UtilFeatureForType<T>]>;
 
 /**
@@ -32,17 +33,21 @@ export async function getFeature<T extends OsmFeatureType>(
 export async function getFeature(
   type: OsmFeatureType,
   id: number,
-  full: true
+  full: true,
+  options?: FetchOptions
 ): Promise<OsmFeature[]>;
 
 export async function getFeature(
   type: OsmFeatureType,
   id: number,
-  full?: boolean
+  full?: boolean,
+  options?: FetchOptions
 ): Promise<OsmFeature[]> {
   const suffix = full && type !== "node" ? "/full" : "";
   const raw = await osmFetch<{ elements: OsmFeature[] }>(
-    `/0.6/${type}/${id}${suffix}.json`
+    `/0.6/${type}/${id}${suffix}.json`,
+    undefined,
+    options
   );
 
   return raw.elements;
@@ -54,10 +59,13 @@ export async function getFeature(
  */
 export async function getFeatures<T extends OsmFeatureType>(
   type: T,
-  ids: (number | string)[]
+  ids: (number | string)[],
+  options?: FetchOptions
 ): Promise<UtilFeatureForType<T>[]> {
   const raw = await osmFetch<{ elements: UtilFeatureForType<T>[] }>(
-    `/0.6/${type}s.json?${type}s=${ids.join(",")}`
+    `/0.6/${type}s.json?${type}s=${ids.join(",")}`,
+    undefined,
+    options
   );
   return raw.elements;
 }
@@ -71,10 +79,13 @@ export async function getFeatures<T extends OsmFeatureType>(
 export async function getFeatureAtVersion<T extends OsmFeatureType>(
   type: T,
   id: number,
-  version: number
+  version: number,
+  options?: FetchOptions
 ): Promise<UtilFeatureForType<T>> {
   const raw = await osmFetch<{ elements: [UtilFeatureForType<T>] }>(
-    `/0.6/${type}/${id}/${version}.json`
+    `/0.6/${type}/${id}/${version}.json`,
+    undefined,
+    options
   );
 
   return raw.elements[0];
@@ -87,19 +98,27 @@ export async function getFeatureAtVersion<T extends OsmFeatureType>(
  */
 export async function getFeatureHistory<T extends OsmFeatureType>(
   type: T,
-  id: number
+  id: number,
+  options?: FetchOptions
 ): Promise<UtilFeatureForType<T>[]> {
   const raw = await osmFetch<{ elements: UtilFeatureForType<T>[] }>(
-    `/0.6/${type}/${id}/history.json`
+    `/0.6/${type}/${id}/history.json`,
+    undefined,
+    options
   );
 
   return raw.elements;
 }
 
 /** gets a list of ways that a node belongs to */
-export async function getWaysForNode(nodeId: number): Promise<OsmWay[]> {
+export async function getWaysForNode(
+  nodeId: number,
+  options?: FetchOptions
+): Promise<OsmWay[]> {
   const raw = await osmFetch<{ elements: OsmWay[] }>(
-    `/0.6/node/${nodeId}/ways.json`
+    `/0.6/node/${nodeId}/ways.json`,
+    undefined,
+    options
   );
   return raw.elements;
 }
@@ -107,10 +126,13 @@ export async function getWaysForNode(nodeId: number): Promise<OsmWay[]> {
 /** gets a list of relations that a node, way, or relation belongs to */
 export async function getRelationsForElement(
   type: OsmFeatureType,
-  id: number
+  id: number,
+  options?: FetchOptions
 ): Promise<OsmRelation[]> {
   const raw = await osmFetch<{ elements: OsmRelation[] }>(
-    `/0.6/${type}/${id}/relations.json`
+    `/0.6/${type}/${id}/relations.json`,
+    undefined,
+    options
   );
   return raw.elements;
 }

--- a/src/api/getMapData.ts
+++ b/src/api/getMapData.ts
@@ -1,5 +1,5 @@
 import type { BBox, OsmFeature } from "../types";
-import { osmFetch } from "./_osmFetch";
+import { type FetchOptions, osmFetch } from "./_osmFetch";
 
 /**
  * This command returns:
@@ -7,10 +7,15 @@ import { osmFetch } from "./_osmFetch";
  * - All ways that reference at least one node that is inside the given bounding box, any relations that reference those ways, and any nodes outside the bounding box that those ways may reference.
  * - All relations that reference one of the nodes, ways or relations included due to the above rules. (Does not apply recursively)
  */
-export async function getMapData(bbox: BBox | string): Promise<OsmFeature[]> {
-  const raw = await osmFetch<{ elements: OsmFeature[] }>("/0.6/map.json", {
-    bbox,
-  });
+export async function getMapData(
+  bbox: BBox | string,
+  options?: FetchOptions
+): Promise<OsmFeature[]> {
+  const raw = await osmFetch<{ elements: OsmFeature[] }>(
+    "/0.6/map.json",
+    { bbox },
+    options
+  );
 
   return raw.elements;
 }

--- a/src/api/getPermissions.ts
+++ b/src/api/getPermissions.ts
@@ -1,11 +1,13 @@
 import type { OsmOAuth2Scopes } from "../auth/types";
-import { osmFetch } from "./_osmFetch";
+import { type FetchOptions, osmFetch } from "./_osmFetch";
 
 export type Permissions = {
   permissions: `allow_${OsmOAuth2Scopes}`[];
 };
 
 /** Gets the OAuth scopes that this app has access to. */
-export async function getPermissions(): Promise<Permissions> {
-  return osmFetch<Permissions>("/0.6/permissions.json");
+export async function getPermissions(
+  options?: FetchOptions
+): Promise<Permissions> {
+  return osmFetch<Permissions>("/0.6/permissions.json", undefined, options);
 }

--- a/src/api/getUser.ts
+++ b/src/api/getUser.ts
@@ -1,14 +1,23 @@
 import type { OsmOwnUser, OsmUser, OsmUserBlock } from "../types";
-import { osmFetch } from "./_osmFetch";
-
-export async function getUser(user: number): Promise<OsmUser>;
-export async function getUser(user: "me"): Promise<OsmOwnUser>;
+import { type FetchOptions, osmFetch } from "./_osmFetch";
 
 export async function getUser(
-  user: number | "me"
+  user: number,
+  options?: FetchOptions
+): Promise<OsmUser>;
+export async function getUser(
+  user: "me",
+  options?: FetchOptions
+): Promise<OsmOwnUser>;
+
+export async function getUser(
+  user: number | "me",
+  options?: FetchOptions
 ): Promise<OsmUser | OsmOwnUser> {
   const raw = await osmFetch<{ user: OsmUser | OsmOwnUser }>(
-    `/0.6/user/${user === "me" ? "details" : user}.json`
+    `/0.6/user/${user === "me" ? "details" : user}.json`,
+    undefined,
+    options
   );
 
   return {
@@ -17,8 +26,15 @@ export async function getUser(
   };
 }
 
-export async function getUsers(users: number[]): Promise<OsmUser[]> {
-  const raw = await osmFetch<{ users: OsmUser[] }>("/0.6/users", { users });
+export async function getUsers(
+  users: number[],
+  options?: FetchOptions
+): Promise<OsmUser[]> {
+  const raw = await osmFetch<{ users: OsmUser[] }>(
+    "/0.6/users",
+    { users },
+    options
+  );
 
   return raw.users.map((u) => ({
     ...u,
@@ -27,18 +43,27 @@ export async function getUsers(users: number[]): Promise<OsmUser[]> {
 }
 
 /** gets details about a DWG block given the ID of the block */
-export async function getUserBlockById(blockId: number): Promise<OsmUserBlock> {
+export async function getUserBlockById(
+  blockId: number,
+  options?: FetchOptions
+): Promise<OsmUserBlock> {
   const raw = await osmFetch<{ user_block: OsmUserBlock }>(
-    `/0.6/user_blocks/${blockId}.json`
+    `/0.6/user_blocks/${blockId}.json`,
+    undefined,
+    options
   );
 
   return raw.user_block;
 }
 
 /** lists any blocks that are currently active for the authenticated user */
-export async function getOwnUserBlocks(): Promise<OsmUserBlock[]> {
+export async function getOwnUserBlocks(
+  options?: FetchOptions
+): Promise<OsmUserBlock[]> {
   const raw = await osmFetch<{ user_blocks: OsmUserBlock[] }>(
-    "/0.6/user/blocks/active"
+    "/0.6/user/blocks/active",
+    undefined,
+    options
   );
 
   return raw.user_blocks;

--- a/src/api/messages/deleteMessage.ts
+++ b/src/api/messages/deleteMessage.ts
@@ -1,11 +1,14 @@
 import type { OsmMessage } from "../../types";
-import { osmFetch } from "../_osmFetch";
+import { type FetchOptions, osmFetch } from "../_osmFetch";
 
-export async function deleteMessage(messageId: number): Promise<OsmMessage> {
+export async function deleteMessage(
+  messageId: number,
+  options?: FetchOptions
+): Promise<OsmMessage> {
   const raw = await osmFetch<{ message: OsmMessage }>(
     `/0.6/user/messages/${messageId}.json`,
     {},
-    { method: "DELETE" }
+    { ...options, method: "DELETE" }
   );
 
   return raw.message;

--- a/src/api/messages/getMessage.ts
+++ b/src/api/messages/getMessage.ts
@@ -1,9 +1,14 @@
 import type { OsmMessage } from "../../types";
-import { osmFetch } from "../_osmFetch";
+import { type FetchOptions, osmFetch } from "../_osmFetch";
 
-export async function getMessage(messageId: number): Promise<OsmMessage> {
+export async function getMessage(
+  messageId: number,
+  options?: FetchOptions
+): Promise<OsmMessage> {
   const raw = await osmFetch<{ message: OsmMessage }>(
-    `/0.6/user/messages/${messageId}.json`
+    `/0.6/user/messages/${messageId}.json`,
+    undefined,
+    options
   );
 
   return raw.message;

--- a/src/api/messages/listMessages.ts
+++ b/src/api/messages/listMessages.ts
@@ -1,11 +1,14 @@
 import type { OsmMessageWithoutBody } from "../../types";
-import { osmFetch } from "../_osmFetch";
+import { type FetchOptions, osmFetch } from "../_osmFetch";
 
 export async function listMessages(
-  type: "inbox" | "outbox"
+  type: "inbox" | "outbox",
+  options?: FetchOptions
 ): Promise<OsmMessageWithoutBody[]> {
   const raw = await osmFetch<{ messages: OsmMessageWithoutBody[] }>(
-    `/0.6/user/messages/${type}.json`
+    `/0.6/user/messages/${type}.json`,
+    undefined,
+    options
   );
 
   return raw.messages;

--- a/src/api/messages/sendMessage.ts
+++ b/src/api/messages/sendMessage.ts
@@ -1,5 +1,5 @@
 import type { OsmMessage } from "../../types";
-import { osmFetch } from "../_osmFetch";
+import { type FetchOptions, osmFetch } from "../_osmFetch";
 
 export interface SendMessageOptions {
   /** Recipient user ID. Specify either `recipient` or `recipient_id`. */
@@ -15,12 +15,13 @@ export interface SendMessageOptions {
 }
 
 export async function sendMessage(
-  options: SendMessageOptions
+  message: SendMessageOptions,
+  options?: FetchOptions
 ): Promise<OsmMessage> {
   const raw = await osmFetch<{ message: OsmMessage }>(
     "/0.6/user/messages.json",
-    options,
-    { method: "POST" }
+    message,
+    { ...options, method: "POST" }
   );
 
   return raw.message;

--- a/src/api/messages/updateMessageReadStatus.ts
+++ b/src/api/messages/updateMessageReadStatus.ts
@@ -1,14 +1,15 @@
 import type { OsmMessage } from "../../types";
-import { osmFetch } from "../_osmFetch";
+import { type FetchOptions, osmFetch } from "../_osmFetch";
 
 export async function updateMessageReadStatus(
   messageId: number,
-  isRead: boolean
+  isRead: boolean,
+  options?: FetchOptions
 ): Promise<OsmMessage> {
   const raw = await osmFetch<{ message: OsmMessage }>(
     `/0.6/user/messages/${messageId}.json`,
     { read_status: isRead },
-    { method: "POST" }
+    { ...options, method: "POST" }
   );
 
   return raw.message;

--- a/src/api/notes/getNotes.ts
+++ b/src/api/notes/getNotes.ts
@@ -1,5 +1,5 @@
 import type { BBox, OsmNote } from "../../types";
-import { osmFetch } from "../_osmFetch";
+import { type FetchOptions, osmFetch } from "../_osmFetch";
 import type { RawNotesSearch } from "../_rawResponse";
 
 const featureToNote = (feature: RawNotesSearch["features"][0]): OsmNote => {
@@ -46,11 +46,13 @@ export type ListNotesOptions = {
 };
 
 async function $getNotes(
-  options: ListNotesOptions | { bbox: string | BBox },
-  suffix: boolean
+  query: ListNotesOptions | { bbox: string | BBox },
+  suffix: boolean,
+  options: FetchOptions | undefined
 ): Promise<OsmNote[]> {
   const raw = await osmFetch<RawNotesSearch>(
     `/0.6/notes${suffix ? "/search" : ""}.json`,
+    query,
     options
   );
 
@@ -65,9 +67,10 @@ async function $getNotes(
  * If no query is specified, the latest notes are returned.
  */
 export function getNotesForQuery(
-  options: ListNotesOptions
+  query: ListNotesOptions,
+  options?: FetchOptions
 ): Promise<OsmNote[]> {
-  return $getNotes(options, true);
+  return $getNotes(query, true, options);
 }
 
 /**
@@ -75,13 +78,21 @@ export function getNotesForQuery(
  * will be ordered by the date of their last change, with the most recent
  * one first.
  */
-export function getNotesForArea(bbox: BBox | string): Promise<OsmNote[]> {
-  return $getNotes({ bbox }, false);
+export function getNotesForArea(
+  bbox: BBox | string,
+  options?: FetchOptions
+): Promise<OsmNote[]> {
+  return $getNotes({ bbox }, false, options);
 }
 
-export async function getNote(noteId: number): Promise<OsmNote> {
+export async function getNote(
+  noteId: number,
+  options?: FetchOptions
+): Promise<OsmNote> {
   const raw = await osmFetch<RawNotesSearch["features"][0]>(
-    `/0.6/notes/${noteId}.json`
+    `/0.6/notes/${noteId}.json`,
+    undefined,
+    options
   );
   return featureToNote(raw);
 }

--- a/src/api/notes/noteActions.ts
+++ b/src/api/notes/noteActions.ts
@@ -1,20 +1,26 @@
-import { osmFetch } from "../_osmFetch";
+import { type FetchOptions, osmFetch } from "../_osmFetch";
 
 export async function createNote(
   lat: number,
   lng: number,
-  text: string
+  text: string,
+  options?: FetchOptions
 ): Promise<void> {
-  await osmFetch("/0.6/notes", { lat, lon: lng, text });
+  await osmFetch("/0.6/notes", { lat, lon: lng, text }, options);
 }
 
 export async function commentOnNote(
   nodeId: number,
-  text: string
+  text: string,
+  options?: FetchOptions
 ): Promise<void> {
-  await osmFetch(`/0.6/notes/${nodeId}/comment`, { text });
+  await osmFetch(`/0.6/notes/${nodeId}/comment`, { text }, options);
 }
 
-export async function reopenNote(nodeId: number, text?: string): Promise<void> {
-  await osmFetch(`/0.6/notes/${nodeId}/reopen`, { text });
+export async function reopenNote(
+  nodeId: number,
+  text?: string,
+  options?: FetchOptions
+): Promise<void> {
+  await osmFetch(`/0.6/notes/${nodeId}/reopen`, { text }, options);
 }

--- a/src/api/notes/subscription.ts
+++ b/src/api/notes/subscription.ts
@@ -1,9 +1,23 @@
-import { osmFetch } from "../_osmFetch";
+import { type FetchOptions, osmFetch } from "../_osmFetch";
 
-export async function subscribeToNote(noteId: number): Promise<void> {
-  await osmFetch(`/0.6/notes/${noteId}/subscription`, {}, { method: "POST" });
+export async function subscribeToNote(
+  noteId: number,
+  options?: FetchOptions
+): Promise<void> {
+  await osmFetch(
+    `/0.6/notes/${noteId}/subscription`,
+    {},
+    { ...options, method: "POST" }
+  );
 }
 
-export async function unsubscribeFromNote(noteId: number): Promise<void> {
-  await osmFetch(`/0.6/notes/${noteId}/subscription`, {}, { method: "DELETE" });
+export async function unsubscribeFromNote(
+  noteId: number,
+  options?: FetchOptions
+): Promise<void> {
+  await osmFetch(
+    `/0.6/notes/${noteId}/subscription`,
+    {},
+    { ...options, method: "DELETE" }
+  );
 }

--- a/src/api/preferences/deletePreferences.ts
+++ b/src/api/preferences/deletePreferences.ts
@@ -1,9 +1,12 @@
-import { osmFetch } from "../_osmFetch";
+import { type FetchOptions, osmFetch } from "../_osmFetch";
 
-export async function deletePreferences(key: string): Promise<void> {
+export async function deletePreferences(
+  key: string,
+  options?: FetchOptions
+): Promise<void> {
   await osmFetch<"">(
     `/0.6/user/preferences/${key}.json`,
     {},
-    { method: "DELETE" }
+    { ...options, method: "DELETE" }
   );
 }

--- a/src/api/preferences/getPreferences.ts
+++ b/src/api/preferences/getPreferences.ts
@@ -1,9 +1,11 @@
 import type { Tags } from "../../types";
-import { osmFetch } from "../_osmFetch";
+import { type FetchOptions, osmFetch } from "../_osmFetch";
 
-export async function getPreferences(): Promise<Tags> {
+export async function getPreferences(options?: FetchOptions): Promise<Tags> {
   const raw = await osmFetch<{ preferences: Tags }>(
-    "/0.6/user/preferences.json"
+    "/0.6/user/preferences.json",
+    undefined,
+    options
   );
 
   return raw.preferences;

--- a/src/api/preferences/updatePreferences.ts
+++ b/src/api/preferences/updatePreferences.ts
@@ -1,12 +1,13 @@
-import { osmFetch } from "../_osmFetch";
+import { type FetchOptions, osmFetch } from "../_osmFetch";
 
 export async function updatePreferences(
   key: string,
-  value: string
+  value: string,
+  options?: FetchOptions
 ): Promise<void> {
   await osmFetch<"">(
     `/0.6/user/preferences/${key}.json`,
     {},
-    { method: "PUT", body: value }
+    { ...options, method: "PUT", body: value }
   );
 }


### PR DESCRIPTION
Closes #16

You can now pass an `AbortSignal` or custom HTTP headers to every API endpoint