### PR TITLE
Point to TS types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "description": "🗺️🌏 Javascript/Typescript wrapper around the OpenStreetMap API",
   "main": "dist",
   "unpkg": "dist/index.min.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "license": "MIT",
   "files": [
     "dist"


### PR DESCRIPTION
Hi, I'm getting this error:

```
Error: Could not find a declaration file for module 'osm-api'. '/home/dabreegster/speedwalk/web/node_modules/osm-api/dist/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/osm-api` if it exists or add a new declaration (.d.ts) file containing `declare module 'osm-api';` (ts)
<script lang="ts">
  import * as OSM from "osm-api";
```

If I make this fix locally in my node_modules, then the errors go away (and I can verify the TS declarations are working, by incorrectly using the library).

Thanks so much for this package; it's going to save me loads of hassle!