### PR TITLE
fix popup auth broken due to new COOP header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 3.0.0 (2025-07-08)
+
+- 💥 BREAKING CHANGE: Fix authentication broken when using the `popup` mode due to [recent security changes](https://github.com/openstreetmap/openstreetmap-website/commit/2ff4d6)
+
 ## 2.7.0 (2025-06-02)
 
 - Optionally support type-safe `Tags`. `Tags` is currently defined as `Record<string, string>`. If you want additional type-safety, you can specify the keys are the allowed. See the docs for more info.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 
 🗺️🌏 Javascript/Typescript wrapper around the OpenStreetMap API.
 
+> [!IMPORTANT]
+> Due to [security changes on 8 July 2025](https://github.com/openstreetmap/openstreetmap-website/commit/2ff4d6), authentication using the `popup` mode will not work until you:
+>
+> 1. update this library to v3.0.0
+> 2. AND update the code snippet in your `land.html` file to the latest version (see [the popup documentation below](#1-popup))
+
 Benefits:
 
 - Lightweight (24 kB gzipped)
@@ -121,8 +127,8 @@ If using a popup, you should create a separate landing page, such as `land.html`
 
 ```html
 <script>
-  if (window.opener) {
-    window.opener.authComplete(location.href);
+  if (new URLSearchParams(location.search).has("code")) {
+    new BroadcastChannel("osm-api-auth-complete").postMessage(location.href);
     window.close();
   }
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osm-api",
-  "version": "2.7.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osm-api",
-      "version": "2.7.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osm-api",
-  "version": "2.7.0",
+  "version": "3.0.0",
   "contributors": [
     "Kyle Hensel (https://github.com/k-yle)"
   ],

--- a/src/__tests__/index.html
+++ b/src/__tests__/index.html
@@ -3,8 +3,8 @@
   Then open http://127.0.0.1:4167/src/__tests__
  -->
 <script>
-  if (window.opener) {
-    window.opener.authComplete(location.href);
+  if (new URLSearchParams(location.search).has("code")) {
+    new BroadcastChannel("osm-api-auth-complete").postMessage(location.href);
     window.close();
   }
 </script>

--- a/src/auth/exchangeCode.ts
+++ b/src/auth/exchangeCode.ts
@@ -56,7 +56,6 @@ export async function exchangeCode(
   localStorage.setItem("__osmAuth", JSON.stringify(loginData));
 
   // At this point, we can consider the login sucessfull
-  delete window.authComplete;
 
   return loginData;
 }

--- a/src/auth/oauth2.ts
+++ b/src/auth/oauth2.ts
@@ -73,10 +73,7 @@ export const authReady: Promise<void> = (async () => {
   const loginState = localStorage.getItem("__osmAuthTemp");
 
   if (new URL(fullUrl).searchParams.get("code")) {
-    if (window.opener?.authComplete) {
-      window.opener.authComplete(fullUrl);
-      window.close();
-    } else if (loginState) {
+    if (loginState) {
       try {
         const transaction: Transaction = JSON.parse(loginState);
         await exchangeCode(fullUrl, transaction);

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -40,10 +40,3 @@ export type Transaction = {
   pkceVerifier: string;
   options: LoginOptions;
 };
-
-/** @internal */
-declare global {
-  interface Window {
-    authComplete?(fullUrl: string): void;
-  }
-}


### PR DESCRIPTION
Caused by https://github.com/openstreetmap/openstreetmap-website/commit/2ff4d6 , also mentioned at https://github.com/osmlab/osm-auth/issues/137

This has already been released to npm as `v3.0.0-beta`, and can be installed using:

```sh
npm i osm-api@beta
```