### PR TITLE
handle linebreaks in tag values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 3.3.1 (2025-11-21)
+
+- [uploadChangeset] fix tag values with linebreaks (`\n`) not handled properly
+
 ## 3.3.0 (2025-09-18)
 
 - [uploadChangeset] add an `onProgress` callback, so that apps can show a progress bar while uploading

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osm-api",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osm-api",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osm-api",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "contributors": [
     "Kyle Hensel (https://github.com/k-yle)"
   ],

--- a/src/__tests__/_createOsmChangeXml.test.ts
+++ b/src/__tests__/_createOsmChangeXml.test.ts
@@ -60,7 +60,7 @@ describe("createOsmChangeXml", () => {
           type: "way",
           id: 4002,
           version: 2,
-          tags: { highway: "path", surface: "< & \" ' >" },
+          tags: { highway: "path", surface: "< & \" ' > \n \r \t" },
           nodes: [3005, 3006, 3007, -3, 3008, 3009, 3010],
         },
         {
@@ -107,7 +107,7 @@ describe("createOsmChangeXml", () => {
     </way>
     <way id="4002" version="2" changeset="6001">
       <tag k="highway" v="path"/>
-      <tag k="surface" v="&lt; &amp; &quot; &apos; &gt;"/>
+      <tag k="surface" v="&lt; &amp; &quot; &apos; &gt; &#10; &#13; &#9;"/>
       <nd ref="3005"/>
       <nd ref="3006"/>
       <nd ref="3007"/>

--- a/src/api/_xml.ts
+++ b/src/api/_xml.ts
@@ -6,4 +6,10 @@ export const xmlParser = new XMLParser({
   attributesGroupName: "$",
   attributeNamePrefix: "",
   isArray: (tagName) => tagName !== "$",
+  attributeValueProcessor(_name, value) {
+    return value
+      .replaceAll(/&#(x9|9);/g, "\t")
+      .replaceAll(/&#(xA|10);/g, "\n")
+      .replaceAll(/&#(xD|13);/g, "\r");
+  },
 });

--- a/src/api/changesets/__tests__/_parseOsmChangeXml.test.ts
+++ b/src/api/changesets/__tests__/_parseOsmChangeXml.test.ts
@@ -18,6 +18,8 @@ describe("_parseOsmChangeXml", () => {
         <modify>
           <way id="-2" version="0" changeset="123">
             <tag k="building" v="yes"/>
+            <tag k="inscription" v="a&#10;b&#13;&#10;c"/>
+            <tag k="surface" v="&lt; &amp; &quot; &apos; &gt; &#10; &#13; &#9;"/>
             <nd ref="10"/>
             <nd ref="11"/>
             <nd ref="12"/>
@@ -55,6 +57,8 @@ describe("_parseOsmChangeXml", () => {
           nodes: [10, 11, 12, 13, 10],
           tags: {
             building: "yes",
+            inscription: "a\nb\r\nc",
+            surface: "< & \" ' > \n \r \t",
           },
           timestamp: undefined,
           type: "way",

--- a/src/api/changesets/_createOsmChangeXml.ts
+++ b/src/api/changesets/_createOsmChangeXml.ts
@@ -7,6 +7,22 @@ const builder = new XMLBuilder({
   format: true,
   suppressEmptyNode: true,
   suppressBooleanAttributes: false,
+  // @ts-expect-error -- typedefs are wrong
+  entities: [
+    { regex: /&/g, val: "&amp;" },
+    { regex: />/g, val: "&gt;" },
+    { regex: /</g, val: "&lt;" },
+    { regex: /'/g, val: "&apos;" },
+    { regex: /"/g, val: "&quot;" },
+    { regex: /\t/g, val: "&#9;" },
+    { regex: /\n/g, val: "&#10;" },
+    { regex: /\r/g, val: "&#13;" },
+    // we need this because the library only defines a subset of
+    // the characters that need to be escaped. compare:
+    // https://github.com/NaturalIntelligence/fast-xml-parser/blob/e0769f/src/xmlbuilder/json2xml.js#L27-L31
+    // with
+    // https://github.com/jsdom/w3c-xmlserializer/blob/83115f/lib/attributes.js#L30-L36
+  ],
 });
 
 /** @internal */


### PR DESCRIPTION
Closes #30

This seems to be a bug with the XML library. The browser's native [`XMLSerializer`](https://developer.mozilla.org/en-US/docs/Web/API/XMLSerializer) handles this properly, and the XML spec mentions this in [§2.11](https://www.w3.org/TR/xml/#sec-line-ends) and [§3.3.3](https://www.w3.org/TR/xml/#AVNormalize).

I'd like to remove the XML library entirely, but this is blocked by https://github.com/openstreetmap/openstreetmap-website/pull/5973...