### PR TITLE
Introduce splitting preferences in chucks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Enhanced preferences API: `getPreference(key, options?)`, `updatePreference(key, value, options?)`, `deletePreference(key, options?)` with `storage: 'auto' | 'single' | 'split'` and optional Standard Schema validation. `getPreferences(options?)` defaults to `handleStorage: 'merged'` (one entry per logical key); use `handleStorage: 'raw'` for API keys as returned. Values over 255 chars are stored as split storage (root + chunks); see [updatePreference.md](./examples/updatePreference.md#split-storage). Backward compatible: `getPreferences()`, `updatePreferences(key, string)`, `deletePreferences(key)` unchanged.
+
 ## 3.3.2 (2026-01-08)
 
 - [getUsers] add type definitions for `social_links`, also switch to the JSON API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Enhanced preferences API: `getPreference(key, options?)`, `updatePreference(key, value, options?)`, `deletePreference(key, options?)` with `storage: 'auto' | 'single' | 'split'` and optional Standard Schema validation. `getPreferences(options?)` defaults to `handleStorage: 'merged'` (one entry per logical key); use `handleStorage: 'raw'` for API keys as returned. Values over 255 chars are stored as split storage (root + chunks); see [updatePreference.md](./examples/updatePreference.md#split-storage). Backward compatible: `getPreferences()`, `updatePreferences(key, string)`, `deletePreferences(key)` unchanged.
+
 ## 4.0.0 (2026-02-11)
 
 - 💥 BREAKING CHANGE: `uploadChangeset` now returns a object instead of a single changeset ID. This is because:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Enhanced preferences API: `getPreference(key, options?)`, `updatePreference(key, value, options?)`, `deletePreference(key, options?)` with `storage: 'auto' | 'single' | 'split'` and optional Standard Schema validation. `getPreferences(options?)` defaults to `handleStorage: 'merged'` (one entry per logical key); use `handleStorage: 'raw'` for API keys as returned. Values over 255 chars are stored as split storage (root + chunks); see [updatePreference.md](./examples/updatePreference.md#split-storage). Backward compatible: `getPreferences()`, `updatePreferences(key, string)`, `deletePreferences(key)` unchanged.
+- 💥 BREAKING CHANGE: `getPreferences()` now returns one merged value per logical preference key by default. Use `getPreferences({ handleStorage: 'raw' })` if you need the raw API keys as returned by the server.
+- Add split-preference storage support with new APIs `getPreference(key, options?)`, `updatePreference(key, value, options?)`, and `deletePreference(key, options?)` (`storage: 'auto' | 'single' | 'split'` plus optional Standard Schema validation). Values over 255 chars are now stored as split storage (root + chunks); see [updatePreference.md](./examples/updatePreference.md#split-storage).
+- Fix preference storage transitions and merged reads so `updatePreference` removes conflicting single/split copies and merged reads deterministically prefer valid split values.
 
 ## 4.0.0 (2026-02-11)
 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,12 @@ All methods return promises. Examples requests and responses are available for a
   - 🔑 [`subscribeToNote()`](./examples/subscribeToNote.md)
   - 🔑 [`unsubscribeFromNote()`](./examples/unsubscribeFromNote.md)
 - Preferences
-  - 🔑 [`getPreferences()`](./examples/getPreferences.md)
-  - 🔑 [`updatePreferences()`](./examples/updatePreferences.md)
-  - 🔑 [`deletePreferences()`](./examples/deletePreferences.md)
+  - 🔑 [`getPreferences()`](./examples/getPreferences.md) (default merged; optional `handleStorage: 'raw'`)
+  - 🔑 [`getPreference(key, options?)`](./examples/getPreference.md) (single key; optional `storage`, schema)
+  - 🔑 [`updatePreference(key, value, options?)`](./examples/updatePreference.md) (JSON value; optional `storage`, schema)
+  - 🔑 [`updatePreferences(key, value)`](./examples/updatePreferences.md) (raw string) — _deprecated_
+  - 🔑 [`deletePreference(key, options?)`](./examples/deletePreference.md) (optional `storage`)
+  - 🔑 [`deletePreferences(key)`](./examples/deletePreferences.md) — _deprecated_
 - Misc
   - [`getApiCapabilities()`](./examples/getApiCapabilities.md)
   - [`getMapData`](./examples/getMapData.md)

--- a/demo/preferences-playground/README.md
+++ b/demo/preferences-playground/README.md
@@ -1,0 +1,57 @@
+# OSM Preferences Playground
+
+Minimal Vite + React demo app for the preference-related examples changed in commits:
+
+- `56061af` (split preference storage introduction)
+- `3f2f55c` (storage transition/merge fixes)
+
+## Run
+
+From this folder:
+
+```bash
+npm install
+npm run dev
+```
+
+Open the printed local URL.
+
+If your environment does not have `npm`, the same commands can be run with Bun:
+
+```bash
+bun install
+bun run dev
+```
+
+## What this app demonstrates
+
+- Server toggle (`dev` default, `live` optional) via `configure({ apiUrl })`
+- Library auth flow (`login`, `logout`, `isLoggedIn`, `authReady`)
+- Preference APIs:
+  - `getPreferences` (merged + raw)
+  - `getPreference` (`auto`, `single`, `split`)
+  - `updatePreference` (`auto`, `single`, `split`)
+  - `deletePreference` (`auto`, `single`, `split`)
+  - `updatePreferences` and `deletePreferences` (deprecated behavior)
+- Step-by-step scenario runs:
+  - baseline single
+  - split
+  - conflict
+  - cleanup
+- Error simulation:
+  - invalid key chars
+  - malformed JSON + schema issues
+  - single overflow
+  - manual broken root/chunk states
+
+## Example docs and source
+
+The app includes direct links to:
+
+- example docs under `examples/*.md`
+- source under `src/api/preferences/*.ts`
+
+## Notes
+
+- Inline styles only, no UI framework.
+- Uses React with readability-first hooks (minimal effects).

--- a/demo/preferences-playground/bun.lock
+++ b/demo/preferences-playground/bun.lock
@@ -1,0 +1,1248 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "preferences-playground",
+      "dependencies": {
+        "osm-api": "file:../..",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+      },
+      "devDependencies": {
+        "vite": "^5.4.10",
+      },
+    },
+  },
+  "packages": {
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/compat": ["@eslint/compat@1.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0" }, "peerDependencies": { "eslint": "^8.40 || 9" }, "optionalPeers": ["eslint"] }, "sha512-cfO82V9zxxGBxcQDr1lfaYB7wykTa0b00mGa36FrJl7iTFd0Z2cHfEYuxcBRP/iNijCsWsEkA+jzT8hGYmv33w=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
+
+    "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
+
+    "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@package-json/types": ["@package-json/types@0.0.12", "", {}, "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw=="],
+
+    "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.2", "", { "os": "android", "cpu": "arm64" }, "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.2", "", { "os": "none", "cpu": "arm64" }, "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/type-utils": "8.59.1", "@typescript-eslint/utils": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.59.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.59.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.59.1", "@typescript-eslint/types": "^8.59.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@7.18.0", "", { "dependencies": { "@typescript-eslint/types": "7.18.0", "@typescript-eslint/visitor-keys": "7.18.0" } }, "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.59.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.59.1", "", { "dependencies": { "@typescript-eslint/types": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1", "@typescript-eslint/utils": "8.59.1", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.59.1", "", {}, "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.59.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.59.1", "@typescript-eslint/tsconfig-utils": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@7.18.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.4.0", "@typescript-eslint/scope-manager": "7.18.0", "@typescript-eslint/types": "7.18.0", "@typescript-eslint/typescript-estree": "7.18.0" }, "peerDependencies": { "eslint": "^8.56.0" } }, "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.1", "", { "dependencies": { "@typescript-eslint/types": "8.59.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg=="],
+
+    "@unrs/resolver-binding-android-arm-eabi": ["@unrs/resolver-binding-android-arm-eabi@1.11.1", "", { "os": "android", "cpu": "arm" }, "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw=="],
+
+    "@unrs/resolver-binding-android-arm64": ["@unrs/resolver-binding-android-arm64@1.11.1", "", { "os": "android", "cpu": "arm64" }, "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g=="],
+
+    "@unrs/resolver-binding-darwin-arm64": ["@unrs/resolver-binding-darwin-arm64@1.11.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g=="],
+
+    "@unrs/resolver-binding-darwin-x64": ["@unrs/resolver-binding-darwin-x64@1.11.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ=="],
+
+    "@unrs/resolver-binding-freebsd-x64": ["@unrs/resolver-binding-freebsd-x64@1.11.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw=="],
+
+    "@unrs/resolver-binding-linux-arm-gnueabihf": ["@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1", "", { "os": "linux", "cpu": "arm" }, "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw=="],
+
+    "@unrs/resolver-binding-linux-arm-musleabihf": ["@unrs/resolver-binding-linux-arm-musleabihf@1.11.1", "", { "os": "linux", "cpu": "arm" }, "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw=="],
+
+    "@unrs/resolver-binding-linux-arm64-gnu": ["@unrs/resolver-binding-linux-arm64-gnu@1.11.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ=="],
+
+    "@unrs/resolver-binding-linux-arm64-musl": ["@unrs/resolver-binding-linux-arm64-musl@1.11.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w=="],
+
+    "@unrs/resolver-binding-linux-ppc64-gnu": ["@unrs/resolver-binding-linux-ppc64-gnu@1.11.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA=="],
+
+    "@unrs/resolver-binding-linux-riscv64-gnu": ["@unrs/resolver-binding-linux-riscv64-gnu@1.11.1", "", { "os": "linux", "cpu": "none" }, "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ=="],
+
+    "@unrs/resolver-binding-linux-riscv64-musl": ["@unrs/resolver-binding-linux-riscv64-musl@1.11.1", "", { "os": "linux", "cpu": "none" }, "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew=="],
+
+    "@unrs/resolver-binding-linux-s390x-gnu": ["@unrs/resolver-binding-linux-s390x-gnu@1.11.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg=="],
+
+    "@unrs/resolver-binding-linux-x64-gnu": ["@unrs/resolver-binding-linux-x64-gnu@1.11.1", "", { "os": "linux", "cpu": "x64" }, "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w=="],
+
+    "@unrs/resolver-binding-linux-x64-musl": ["@unrs/resolver-binding-linux-x64-musl@1.11.1", "", { "os": "linux", "cpu": "x64" }, "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA=="],
+
+    "@unrs/resolver-binding-wasm32-wasi": ["@unrs/resolver-binding-wasm32-wasi@1.11.1", "", { "dependencies": { "@napi-rs/wasm-runtime": "^0.2.11" }, "cpu": "none" }, "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ=="],
+
+    "@unrs/resolver-binding-win32-arm64-msvc": ["@unrs/resolver-binding-win32-arm64-msvc@1.11.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw=="],
+
+    "@unrs/resolver-binding-win32-ia32-msvc": ["@unrs/resolver-binding-win32-ia32-msvc@1.11.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ=="],
+
+    "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
+
+    "@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.12" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@2.1.9", "", { "dependencies": { "tinyrainbow": "^1.2.0" } }, "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ=="],
+
+    "@vitest/runner": ["@vitest/runner@2.1.9", "", { "dependencies": { "@vitest/utils": "2.1.9", "pathe": "^1.1.2" } }, "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "magic-string": "^0.30.12", "pathe": "^1.1.2" } }, "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ=="],
+
+    "@vitest/spy": ["@vitest/spy@2.1.9", "", { "dependencies": { "tinyspy": "^3.0.2" } }, "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ=="],
+
+    "@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
+
+    "JSONStream": ["JSONStream@1.3.5", "", { "dependencies": { "jsonparse": "^1.2.0", "through": ">=2.2.7 <3" }, "bin": { "JSONStream": "./bin.js" } }, "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "acorn-node": ["acorn-node@1.8.2", "", { "dependencies": { "acorn": "^7.0.0", "acorn-walk": "^7.0.0", "xtend": "^4.0.2" } }, "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A=="],
+
+    "acorn-walk": ["acorn-walk@7.2.0", "", {}, "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="],
+
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
+
+    "array-includes": ["array-includes@3.1.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.0", "es-object-atoms": "^1.1.1", "get-intrinsic": "^1.3.0", "is-string": "^1.1.1", "math-intrinsics": "^1.1.0" } }, "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ=="],
+
+    "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
+
+    "array.prototype.findlast": ["array.prototype.findlast@1.2.5", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "es-shim-unscopables": "^1.0.2" } }, "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ=="],
+
+    "array.prototype.flat": ["array.prototype.flat@1.3.3", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-shim-unscopables": "^1.0.2" } }, "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg=="],
+
+    "array.prototype.flatmap": ["array.prototype.flatmap@1.3.3", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-shim-unscopables": "^1.0.2" } }, "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg=="],
+
+    "array.prototype.tosorted": ["array.prototype.tosorted@1.1.4", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3", "es-errors": "^1.3.0", "es-shim-unscopables": "^1.0.2" } }, "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA=="],
+
+    "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
+
+    "asn1.js": ["asn1.js@4.10.1", "", { "dependencies": { "bn.js": "^4.0.0", "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0" } }, "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw=="],
+
+    "assert": ["assert@1.5.1", "", { "dependencies": { "object.assign": "^4.1.4", "util": "^0.10.4" } }, "sha512-zzw1uCAgLbsKwBfFc8CX78DDg+xZeBksSO3vwVIDDN5i94eOrPsSSyiVhmsSABFDM/OcpE2aagCat9dnWQLG1A=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-types-flow": ["ast-types-flow@0.0.8", "", {}, "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="],
+
+    "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
+
+    "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
+
+    "axe-core": ["axe-core@4.11.4", "", {}, "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.24", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA=="],
+
+    "bn.js": ["bn.js@5.2.3", "", {}, "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w=="],
+
+    "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "brorand": ["brorand@1.1.0", "", {}, "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="],
+
+    "browser-pack": ["browser-pack@6.1.0", "", { "dependencies": { "JSONStream": "^1.0.3", "combine-source-map": "~0.8.0", "defined": "^1.0.0", "safe-buffer": "^5.1.1", "through2": "^2.0.0", "umd": "^3.0.0" }, "bin": { "browser-pack": "bin/cmd.js" } }, "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA=="],
+
+    "browser-resolve": ["browser-resolve@2.0.0", "", { "dependencies": { "resolve": "^1.17.0" } }, "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ=="],
+
+    "browserify": ["browserify@17.0.1", "", { "dependencies": { "JSONStream": "^1.0.3", "assert": "^1.4.0", "browser-pack": "^6.0.1", "browser-resolve": "^2.0.0", "browserify-zlib": "~0.2.0", "buffer": "~5.2.1", "cached-path-relative": "^1.0.0", "concat-stream": "^1.6.0", "console-browserify": "^1.1.0", "constants-browserify": "~1.0.0", "crypto-browserify": "^3.0.0", "defined": "^1.0.0", "deps-sort": "^2.0.1", "domain-browser": "^1.2.0", "duplexer2": "~0.1.2", "events": "^3.0.0", "glob": "^7.1.0", "hasown": "^2.0.0", "htmlescape": "^1.1.0", "https-browserify": "^1.0.0", "inherits": "~2.0.1", "insert-module-globals": "^7.2.1", "labeled-stream-splicer": "^2.0.0", "mkdirp-classic": "^0.5.2", "module-deps": "^6.2.3", "os-browserify": "~0.3.0", "parents": "^1.0.1", "path-browserify": "^1.0.0", "process": "~0.11.0", "punycode": "^1.3.2", "querystring-es3": "~0.2.0", "read-only-stream": "^2.0.0", "readable-stream": "^2.0.2", "resolve": "^1.1.4", "shasum-object": "^1.0.0", "shell-quote": "^1.6.1", "stream-browserify": "^3.0.0", "stream-http": "^3.0.0", "string_decoder": "^1.1.1", "subarg": "^1.0.0", "syntax-error": "^1.1.1", "through2": "^2.0.0", "timers-browserify": "^1.0.1", "tty-browserify": "0.0.1", "url": "~0.11.0", "util": "~0.12.0", "vm-browserify": "^1.0.0", "xtend": "^4.0.0" }, "bin": { "browserify": "bin/cmd.js" } }, "sha512-pxhT00W3ylMhCHwG5yfqtZjNnFuX5h2IJdaBfSo4ChaaBsIp9VLrEMQ1bHV+Xr1uLPXuNDDM1GlJkjli0qkRsw=="],
+
+    "browserify-aes": ["browserify-aes@1.2.0", "", { "dependencies": { "buffer-xor": "^1.0.3", "cipher-base": "^1.0.0", "create-hash": "^1.1.0", "evp_bytestokey": "^1.0.3", "inherits": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA=="],
+
+    "browserify-cipher": ["browserify-cipher@1.0.1", "", { "dependencies": { "browserify-aes": "^1.0.4", "browserify-des": "^1.0.0", "evp_bytestokey": "^1.0.0" } }, "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w=="],
+
+    "browserify-des": ["browserify-des@1.0.2", "", { "dependencies": { "cipher-base": "^1.0.1", "des.js": "^1.0.0", "inherits": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A=="],
+
+    "browserify-rsa": ["browserify-rsa@4.1.1", "", { "dependencies": { "bn.js": "^5.2.1", "randombytes": "^2.1.0", "safe-buffer": "^5.2.1" } }, "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ=="],
+
+    "browserify-sign": ["browserify-sign@4.2.5", "", { "dependencies": { "bn.js": "^5.2.2", "browserify-rsa": "^4.1.1", "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "elliptic": "^6.6.1", "inherits": "^2.0.4", "parse-asn1": "^5.1.9", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1" } }, "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw=="],
+
+    "browserify-zlib": ["browserify-zlib@0.2.0", "", { "dependencies": { "pako": "~1.0.5" } }, "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "buffer": ["buffer@5.2.1", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4" } }, "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg=="],
+
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "buffer-xor": ["buffer-xor@1.0.3", "", {}, "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="],
+
+    "builtin-modules": ["builtin-modules@3.3.0", "", {}, "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw=="],
+
+    "builtin-status-codes": ["builtin-status-codes@3.0.0", "", {}, "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "cached-path-relative": ["cached-path-relative@1.1.0", "", {}, "sha512-WF0LihfemtesFcJgO7xfOoOcnWzY/QHR4qeDqV44jPU3HTI54+LnfXK3SA27AVVGCdZFgjjFFaqUA9Jx7dMJZA=="],
+
+    "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001791", "", {}, "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
+
+    "cipher-base": ["cipher-base@1.0.7", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.2" } }, "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA=="],
+
+    "clean-regexp": ["clean-regexp@1.0.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "combine-source-map": ["combine-source-map@0.8.0", "", { "dependencies": { "convert-source-map": "~1.1.0", "inline-source-map": "~0.6.0", "lodash.memoize": "~3.0.3", "source-map": "~0.5.3" } }, "sha512-UlxQ9Vw0b/Bt/KYwCFqdEwsQ1eL8d1gibiFb7lxQJFdvTgc2hIZi6ugsg+kyhzhPV+QEpUiEIwInIAIrgoEkrg=="],
+
+    "comment-parser": ["comment-parser@1.4.6", "", {}, "sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "concat-stream": ["concat-stream@1.6.2", "", { "dependencies": { "buffer-from": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^2.2.2", "typedarray": "^0.0.6" } }, "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw=="],
+
+    "confusing-browser-globals": ["confusing-browser-globals@1.0.11", "", {}, "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA=="],
+
+    "console-browserify": ["console-browserify@1.2.0", "", {}, "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="],
+
+    "constants-browserify": ["constants-browserify@1.0.0", "", {}, "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ=="],
+
+    "convert-source-map": ["convert-source-map@1.9.0", "", {}, "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="],
+
+    "core-js-compat": ["core-js-compat@3.49.0", "", { "dependencies": { "browserslist": "^4.28.1" } }, "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA=="],
+
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "create-ecdh": ["create-ecdh@4.0.4", "", { "dependencies": { "bn.js": "^4.1.0", "elliptic": "^6.5.3" } }, "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A=="],
+
+    "create-hash": ["create-hash@1.2.0", "", { "dependencies": { "cipher-base": "^1.0.1", "inherits": "^2.0.1", "md5.js": "^1.3.4", "ripemd160": "^2.0.1", "sha.js": "^2.4.0" } }, "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg=="],
+
+    "create-hmac": ["create-hmac@1.1.7", "", { "dependencies": { "cipher-base": "^1.0.3", "create-hash": "^1.1.0", "inherits": "^2.0.1", "ripemd160": "^2.0.0", "safe-buffer": "^5.0.1", "sha.js": "^2.4.8" } }, "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "crypto-browserify": ["crypto-browserify@3.12.1", "", { "dependencies": { "browserify-cipher": "^1.0.1", "browserify-sign": "^4.2.3", "create-ecdh": "^4.0.4", "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "diffie-hellman": "^5.0.3", "hash-base": "~3.0.4", "inherits": "^2.0.4", "pbkdf2": "^3.1.2", "public-encrypt": "^4.0.3", "randombytes": "^2.1.0", "randomfill": "^1.0.4" } }, "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ=="],
+
+    "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
+
+    "dash-ast": ["dash-ast@1.0.0", "", {}, "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA=="],
+
+    "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
+
+    "data-view-byte-length": ["data-view-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ=="],
+
+    "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
+    "defined": ["defined@1.0.1", "", {}, "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q=="],
+
+    "deps-sort": ["deps-sort@2.0.1", "", { "dependencies": { "JSONStream": "^1.0.3", "shasum-object": "^1.0.0", "subarg": "^1.0.0", "through2": "^2.0.0" }, "bin": { "deps-sort": "bin/cmd.js" } }, "sha512-1orqXQr5po+3KI6kQb9A4jnXT1PBwggGl2d7Sq2xsnOeI9GPcE/tGcF9UiSZtZBM7MukY4cAh7MemS6tZYipfw=="],
+
+    "des.js": ["des.js@1.1.0", "", { "dependencies": { "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0" } }, "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg=="],
+
+    "detective": ["detective@5.2.1", "", { "dependencies": { "acorn-node": "^1.8.2", "defined": "^1.0.0", "minimist": "^1.2.6" }, "bin": { "detective": "bin/detective.js" } }, "sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw=="],
+
+    "diffie-hellman": ["diffie-hellman@5.0.3", "", { "dependencies": { "bn.js": "^4.1.0", "miller-rabin": "^4.0.0", "randombytes": "^2.0.0" } }, "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg=="],
+
+    "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
+
+    "domain-browser": ["domain-browser@1.2.0", "", {}, "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "duplexer2": ["duplexer2@0.1.4", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.345", "", {}, "sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg=="],
+
+    "elliptic": ["elliptic@6.6.1", "", { "dependencies": { "bn.js": "^4.11.9", "brorand": "^1.1.0", "hash.js": "^1.0.0", "hmac-drbg": "^1.0.1", "inherits": "^2.0.4", "minimalistic-assert": "^1.0.1", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
+
+    "es-abstract": ["es-abstract@1.24.2", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-iterator-helpers": ["es-iterator-helpers@1.3.2", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.2", "es-errors": "^1.3.0", "es-set-tostringtag": "^2.1.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.3.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "iterator.prototype": "^1.1.5", "math-intrinsics": "^1.1.0" } }, "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw=="],
+
+    "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
+
+    "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
+
+    "eslint-config-kyle": ["eslint-config-kyle@25.0.0", "", { "dependencies": { "@eslint/compat": "^1.2.3", "@eslint/js": "^9.16.0", "confusing-browser-globals": "^1.0.11", "eslint-config-prettier": "^9.1.0", "eslint-plugin-import-x": "^4.5.0", "eslint-plugin-jsx-a11y": "^6.10.2", "eslint-plugin-prettier": "^5.2.1", "eslint-plugin-react": "^7.37.2", "eslint-plugin-react-hooks": "^5.0.0", "eslint-plugin-unicorn": "^56.0.1", "eslint-plugin-vitest": "^0.5.4", "globals": "^15.13.0", "prettier": "^3.4.1", "typescript-eslint": "^8.17.0" } }, "sha512-mDdsv/Q7mdGwfaMSPyv6NPe+jriaZYU0gJzcz7JPqOk+Ah+p42Xp8piF6l43OiRldFuoSyJE+hKJL/UH0vb1+Q=="],
+
+    "eslint-config-prettier": ["eslint-config-prettier@9.1.2", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ=="],
+
+    "eslint-import-context": ["eslint-import-context@0.1.9", "", { "dependencies": { "get-tsconfig": "^4.10.1", "stable-hash-x": "^0.2.0" }, "peerDependencies": { "unrs-resolver": "^1.0.0" }, "optionalPeers": ["unrs-resolver"] }, "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg=="],
+
+    "eslint-plugin-import-x": ["eslint-plugin-import-x@4.16.2", "", { "dependencies": { "@package-json/types": "^0.0.12", "@typescript-eslint/types": "^8.56.0", "comment-parser": "^1.4.1", "debug": "^4.4.1", "eslint-import-context": "^0.1.9", "is-glob": "^4.0.3", "minimatch": "^9.0.3 || ^10.1.2", "semver": "^7.7.2", "stable-hash-x": "^0.2.0", "unrs-resolver": "^1.9.2" }, "peerDependencies": { "@typescript-eslint/utils": "^8.56.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "eslint-import-resolver-node": "*" }, "optionalPeers": ["@typescript-eslint/utils", "eslint-import-resolver-node"] }, "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw=="],
+
+    "eslint-plugin-jsx-a11y": ["eslint-plugin-jsx-a11y@6.10.2", "", { "dependencies": { "aria-query": "^5.3.2", "array-includes": "^3.1.8", "array.prototype.flatmap": "^1.3.2", "ast-types-flow": "^0.0.8", "axe-core": "^4.10.0", "axobject-query": "^4.1.0", "damerau-levenshtein": "^1.0.8", "emoji-regex": "^9.2.2", "hasown": "^2.0.2", "jsx-ast-utils": "^3.3.5", "language-tags": "^1.0.9", "minimatch": "^3.1.2", "object.fromentries": "^2.0.8", "safe-regex-test": "^1.0.3", "string.prototype.includes": "^2.0.1" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9" } }, "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q=="],
+
+    "eslint-plugin-prettier": ["eslint-plugin-prettier@5.5.5", "", { "dependencies": { "prettier-linter-helpers": "^1.0.1", "synckit": "^0.11.12" }, "peerDependencies": { "@types/eslint": ">=8.0.0", "eslint": ">=8.0.0", "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0", "prettier": ">=3.0.0" }, "optionalPeers": ["@types/eslint", "eslint-config-prettier"] }, "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw=="],
+
+    "eslint-plugin-react": ["eslint-plugin-react@7.37.5", "", { "dependencies": { "array-includes": "^3.1.8", "array.prototype.findlast": "^1.2.5", "array.prototype.flatmap": "^1.3.3", "array.prototype.tosorted": "^1.1.4", "doctrine": "^2.1.0", "es-iterator-helpers": "^1.2.1", "estraverse": "^5.3.0", "hasown": "^2.0.2", "jsx-ast-utils": "^2.4.1 || ^3.0.0", "minimatch": "^3.1.2", "object.entries": "^1.1.9", "object.fromentries": "^2.0.8", "object.values": "^1.2.1", "prop-types": "^15.8.1", "resolve": "^2.0.0-next.5", "semver": "^6.3.1", "string.prototype.matchall": "^4.0.12", "string.prototype.repeat": "^1.0.0" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" } }, "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA=="],
+
+    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@5.2.0", "", { "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0" } }, "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg=="],
+
+    "eslint-plugin-unicorn": ["eslint-plugin-unicorn@56.0.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.24.7", "@eslint-community/eslint-utils": "^4.4.0", "ci-info": "^4.0.0", "clean-regexp": "^1.0.0", "core-js-compat": "^3.38.1", "esquery": "^1.6.0", "globals": "^15.9.0", "indent-string": "^4.0.0", "is-builtin-module": "^3.2.1", "jsesc": "^3.0.2", "pluralize": "^8.0.0", "read-pkg-up": "^7.0.1", "regexp-tree": "^0.1.27", "regjsparser": "^0.10.0", "semver": "^7.6.3", "strip-indent": "^3.0.0" }, "peerDependencies": { "eslint": ">=8.56.0" } }, "sha512-FwVV0Uwf8XPfVnKSGpMg7NtlZh0G0gBarCaFcMUOoqPxXryxdYxTRRv4kH6B9TFCVIrjRXG+emcxIk2ayZilog=="],
+
+    "eslint-plugin-vitest": ["eslint-plugin-vitest@0.5.4", "", { "dependencies": { "@typescript-eslint/utils": "^7.7.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "vitest": "*" }, "optionalPeers": ["vitest"] }, "sha512-um+odCkccAHU53WdKAw39MY61+1x990uXjSPguUCq3VcEHdqJrOb8OTMrbYlY6f9jAKx7x98kLVlIe3RJeJqoQ=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
+    "evp_bytestokey": ["evp_bytestokey@1.0.3", "", { "dependencies": { "md5.js": "^1.3.4", "safe-buffer": "^5.1.1" } }, "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-diff": ["fast-diff@1.3.0", "", {}, "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
+
+    "fast-xml-parser": ["fast-xml-parser@4.5.6", "", { "dependencies": { "strnum": "^1.0.5" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "function.prototype.name": ["function.prototype.name@1.1.8", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "functions-have-names": "^1.2.3", "hasown": "^2.0.2", "is-callable": "^1.2.7" } }, "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q=="],
+
+    "functions-have-names": ["functions-have-names@1.2.3", "", {}, "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="],
+
+    "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
+
+    "get-assigned-identifiers": ["get-assigned-identifiers@1.2.0", "", {}, "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
+    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@15.15.0", "", {}, "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg=="],
+
+    "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
+
+    "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
+
+    "has-proto": ["has-proto@1.2.0", "", { "dependencies": { "dunder-proto": "^1.0.0" } }, "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hash-base": ["hash-base@3.0.5", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1" } }, "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg=="],
+
+    "hash.js": ["hash.js@1.1.7", "", { "dependencies": { "inherits": "^2.0.3", "minimalistic-assert": "^1.0.1" } }, "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "hmac-drbg": ["hmac-drbg@1.0.1", "", { "dependencies": { "hash.js": "^1.0.3", "minimalistic-assert": "^1.0.0", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg=="],
+
+    "hosted-git-info": ["hosted-git-info@2.8.9", "", {}, "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="],
+
+    "htmlescape": ["htmlescape@1.1.1", "", {}, "sha512-eVcrzgbR4tim7c7soKQKtxa/kQM4TzjnlU83rcZ9bHU6t31ehfV7SktN6McWgwPWg+JYMA/O3qpGxBvFq1z2Jg=="],
+
+    "https-browserify": ["https-browserify@1.0.0", "", {}, "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "inline-source-map": ["inline-source-map@0.6.3", "", { "dependencies": { "source-map": "~0.5.3" } }, "sha512-1aVsPEsJWMJq/pdMU61CDlm1URcW702MTB4w9/zUjMus6H/Py8o7g68Pr9D4I6QluWGt/KdmswuRhaA05xVR1w=="],
+
+    "insert-module-globals": ["insert-module-globals@7.2.1", "", { "dependencies": { "JSONStream": "^1.0.3", "acorn-node": "^1.5.2", "combine-source-map": "^0.8.0", "concat-stream": "^1.6.1", "is-buffer": "^1.1.0", "path-is-absolute": "^1.0.1", "process": "~0.11.0", "through2": "^2.0.0", "undeclared-identifiers": "^1.1.2", "xtend": "^4.0.0" }, "bin": { "insert-module-globals": "bin/cmd.js" } }, "sha512-ufS5Qq9RZN+Bu899eA9QCAYThY+gGW7oRkmb0vC93Vlyu/CFGcH0OYPEjVkDXA5FEbTt1+VWzdoOD3Ny9N+8tg=="],
+
+    "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
+
+    "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
+
+    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
+    "is-async-function": ["is-async-function@2.1.1", "", { "dependencies": { "async-function": "^1.0.0", "call-bound": "^1.0.3", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ=="],
+
+    "is-bigint": ["is-bigint@1.1.0", "", { "dependencies": { "has-bigints": "^1.0.2" } }, "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ=="],
+
+    "is-boolean-object": ["is-boolean-object@1.2.2", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A=="],
+
+    "is-buffer": ["is-buffer@1.1.6", "", {}, "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="],
+
+    "is-builtin-module": ["is-builtin-module@3.2.1", "", { "dependencies": { "builtin-modules": "^3.3.0" } }, "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A=="],
+
+    "is-callable": ["is-callable@1.2.7", "", {}, "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="],
+
+    "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
+
+    "is-data-view": ["is-data-view@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "is-typed-array": "^1.1.13" } }, "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw=="],
+
+    "is-date-object": ["is-date-object@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
+
+    "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-map": ["is-map@2.0.3", "", {}, "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="],
+
+    "is-negative-zero": ["is-negative-zero@2.0.3", "", {}, "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-number-object": ["is-number-object@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw=="],
+
+    "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
+
+    "is-set": ["is-set@2.0.3", "", {}, "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg=="],
+
+    "is-shared-array-buffer": ["is-shared-array-buffer@1.0.4", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A=="],
+
+    "is-string": ["is-string@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA=="],
+
+    "is-symbol": ["is-symbol@1.1.1", "", { "dependencies": { "call-bound": "^1.0.2", "has-symbols": "^1.1.0", "safe-regex-test": "^1.1.0" } }, "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w=="],
+
+    "is-typed-array": ["is-typed-array@1.1.15", "", { "dependencies": { "which-typed-array": "^1.1.16" } }, "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ=="],
+
+    "is-utf8": ["is-utf8@0.2.1", "", {}, "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="],
+
+    "is-weakmap": ["is-weakmap@2.0.2", "", {}, "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w=="],
+
+    "is-weakref": ["is-weakref@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew=="],
+
+    "is-weakset": ["is-weakset@2.0.4", "", { "dependencies": { "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ=="],
+
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "jsonparse": ["jsonparse@1.3.1", "", {}, "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="],
+
+    "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "labeled-stream-splicer": ["labeled-stream-splicer@2.0.2", "", { "dependencies": { "inherits": "^2.0.1", "stream-splicer": "^2.0.0" } }, "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw=="],
+
+    "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],
+
+    "language-tags": ["language-tags@1.0.9", "", { "dependencies": { "language-subtag-registry": "^0.3.20" } }, "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.memoize": ["lodash.memoize@3.0.4", "", {}, "sha512-eDn9kqrAmVUC1wmZvlQ6Uhde44n+tXpqPrN8olQJbttgh0oKclk+SF54P47VEGE9CEiMeRwAP8BaM7UHvBkz2A=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "md5.js": ["md5.js@1.3.5", "", { "dependencies": { "hash-base": "^3.0.0", "inherits": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "miller-rabin": ["miller-rabin@4.0.1", "", { "dependencies": { "bn.js": "^4.0.0", "brorand": "^1.0.1" }, "bin": { "miller-rabin": "bin/miller-rabin" } }, "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
+    "minimalistic-assert": ["minimalistic-assert@1.0.1", "", {}, "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="],
+
+    "minimalistic-crypto-utils": ["minimalistic-crypto-utils@1.0.1", "", {}, "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="],
+
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
+    "module-deps": ["module-deps@6.2.3", "", { "dependencies": { "JSONStream": "^1.0.3", "browser-resolve": "^2.0.0", "cached-path-relative": "^1.0.2", "concat-stream": "~1.6.0", "defined": "^1.0.0", "detective": "^5.2.0", "duplexer2": "^0.1.2", "inherits": "^2.0.1", "parents": "^1.0.0", "readable-stream": "^2.0.2", "resolve": "^1.4.0", "stream-combiner2": "^1.1.1", "subarg": "^1.0.0", "through2": "^2.0.0", "xtend": "^4.0.0" }, "bin": { "module-deps": "bin/cmd.js" } }, "sha512-fg7OZaQBcL4/L+AK5f4iVqf9OMbCclXfy/znXRxTVhJSeW5AIlS9AwheYwDaXM3lVW7OBeaeUEY3gbaC6cLlSA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
+
+    "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
+
+    "normalize-package-data": ["normalize-package-data@2.5.0", "", { "dependencies": { "hosted-git-info": "^2.1.4", "resolve": "^1.10.0", "semver": "2 || 3 || 4 || 5", "validate-npm-package-license": "^3.0.1" } }, "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
+    "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
+
+    "object.entries": ["object.entries@1.1.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-object-atoms": "^1.1.1" } }, "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw=="],
+
+    "object.fromentries": ["object.fromentries@2.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2", "es-object-atoms": "^1.0.0" } }, "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ=="],
+
+    "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "os-browserify": ["os-browserify@0.3.0", "", {}, "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A=="],
+
+    "osm-api": ["osm-api@file:../..", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/geojson": "^7946.0.13", "fast-xml-parser": "^4.4.1" }, "devDependencies": { "@types/node": "^22.5.5", "browserify": "^17.0.0", "eslint": "^9.10.0", "eslint-config-kyle": "^25.0.0-beta3", "tsify": "^5.0.4", "typescript": "^5.6.2", "uglify-js": "^3.19.3", "vitest": "^2.1.1" } }],
+
+    "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parents": ["parents@1.0.1", "", { "dependencies": { "path-platform": "~0.11.15" } }, "sha512-mXKF3xkoUt5td2DoxpLmtOmZvko9VfFpwRwkKDHSNvgmpLAeBo18YDhcPbBzJq+QLCHMbGOfzia2cX4U+0v9Mg=="],
+
+    "parse-asn1": ["parse-asn1@5.1.9", "", { "dependencies": { "asn1.js": "^4.10.1", "browserify-aes": "^1.2.0", "evp_bytestokey": "^1.0.3", "pbkdf2": "^3.1.5", "safe-buffer": "^5.2.1" } }, "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg=="],
+
+    "parse-json": ["parse-json@2.2.0", "", { "dependencies": { "error-ex": "^1.2.0" } }, "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ=="],
+
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "path-platform": ["path-platform@0.11.15", "", {}, "sha512-Y30dB6rab1A/nfEKsZxmr01nUotHX0c/ZiIAsCTatEe1CmS5Pm5He7fZ195bPT7RdquoaL8lLxFCMQi/bS7IJg=="],
+
+    "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
+
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "pbkdf2": ["pbkdf2@3.1.5", "", { "dependencies": { "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "ripemd160": "^2.0.3", "safe-buffer": "^5.2.1", "sha.js": "^2.4.12", "to-buffer": "^1.2.1" } }, "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
+
+    "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
+
+    "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
+
+    "prettier-linter-helpers": ["prettier-linter-helpers@1.0.1", "", { "dependencies": { "fast-diff": "^1.1.2" } }, "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg=="],
+
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
+    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
+    "public-encrypt": ["public-encrypt@4.0.3", "", { "dependencies": { "bn.js": "^4.1.0", "browserify-rsa": "^4.0.0", "create-hash": "^1.1.0", "parse-asn1": "^5.0.0", "randombytes": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q=="],
+
+    "punycode": ["punycode@1.4.1", "", {}, "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "querystring-es3": ["querystring-es3@0.2.1", "", {}, "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
+
+    "randomfill": ["randomfill@1.0.4", "", { "dependencies": { "randombytes": "^2.0.5", "safe-buffer": "^5.1.0" } }, "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw=="],
+
+    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
+    "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
+
+    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "read-only-stream": ["read-only-stream@2.0.0", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-3ALe0bjBVZtkdWKIcThYpQCLbBMd/+Tbh2CDSrAIDO3UsZ4Xs+tnyjv2MjCOMMgBG+AsUOeuP1cgtY1INISc8w=="],
+
+    "read-pkg": ["read-pkg@5.2.0", "", { "dependencies": { "@types/normalize-package-data": "^2.4.0", "normalize-package-data": "^2.5.0", "parse-json": "^5.0.0", "type-fest": "^0.6.0" } }, "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg=="],
+
+    "read-pkg-up": ["read-pkg-up@7.0.1", "", { "dependencies": { "find-up": "^4.1.0", "read-pkg": "^5.2.0", "type-fest": "^0.8.1" } }, "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg=="],
+
+    "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
+
+    "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
+
+    "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
+
+    "regjsparser": ["regjsparser@0.10.0", "", { "dependencies": { "jsesc": "~0.5.0" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA=="],
+
+    "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "ripemd160": ["ripemd160@2.0.3", "", { "dependencies": { "hash-base": "^3.1.2", "inherits": "^2.0.4" } }, "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA=="],
+
+    "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "safe-array-concat": ["safe-array-concat@1.1.4", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "get-intrinsic": "^1.3.0", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
+
+    "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
+
+    "set-function-name": ["set-function-name@2.0.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2" } }, "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ=="],
+
+    "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
+
+    "sha.js": ["sha.js@2.4.12", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.0" }, "bin": { "sha.js": "bin.js" } }, "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w=="],
+
+    "shasum-object": ["shasum-object@1.0.1", "", { "dependencies": { "fast-safe-stringify": "^2.0.7" }, "bin": { "shasum-object": "bin.js" } }, "sha512-SsC+1tW7XKQ/94D4k1JhLmjDFpVGET/Nf54jVDtbavbALf8Zhp0Td9zTlxScjMW6nbEIrpADtPWfLk9iCXzHDQ=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "spdx-correct": ["spdx-correct@3.2.0", "", { "dependencies": { "spdx-expression-parse": "^3.0.0", "spdx-license-ids": "^3.0.0" } }, "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA=="],
+
+    "spdx-exceptions": ["spdx-exceptions@2.5.0", "", {}, "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="],
+
+    "spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
+
+    "spdx-license-ids": ["spdx-license-ids@3.0.23", "", {}, "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw=="],
+
+    "stable-hash-x": ["stable-hash-x@0.2.0", "", {}, "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
+
+    "stream-browserify": ["stream-browserify@3.0.0", "", { "dependencies": { "inherits": "~2.0.4", "readable-stream": "^3.5.0" } }, "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA=="],
+
+    "stream-combiner2": ["stream-combiner2@1.1.1", "", { "dependencies": { "duplexer2": "~0.1.0", "readable-stream": "^2.0.2" } }, "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw=="],
+
+    "stream-http": ["stream-http@3.2.0", "", { "dependencies": { "builtin-status-codes": "^3.0.0", "inherits": "^2.0.4", "readable-stream": "^3.6.0", "xtend": "^4.0.2" } }, "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A=="],
+
+    "stream-splicer": ["stream-splicer@2.0.1", "", { "dependencies": { "inherits": "^2.0.1", "readable-stream": "^2.0.2" } }, "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg=="],
+
+    "string.prototype.includes": ["string.prototype.includes@2.0.1", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3" } }, "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg=="],
+
+    "string.prototype.matchall": ["string.prototype.matchall@4.0.12", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-abstract": "^1.23.6", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "regexp.prototype.flags": "^1.5.3", "set-function-name": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA=="],
+
+    "string.prototype.repeat": ["string.prototype.repeat@1.0.0", "", { "dependencies": { "define-properties": "^1.1.3", "es-abstract": "^1.17.5" } }, "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w=="],
+
+    "string.prototype.trim": ["string.prototype.trim@1.2.10", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "define-data-property": "^1.1.4", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-object-atoms": "^1.0.0", "has-property-descriptors": "^1.0.2" } }, "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA=="],
+
+    "string.prototype.trimend": ["string.prototype.trimend@1.0.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ=="],
+
+    "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "strip-bom": ["strip-bom@2.0.0", "", { "dependencies": { "is-utf8": "^0.2.0" } }, "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "strnum": ["strnum@1.1.2", "", {}, "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA=="],
+
+    "subarg": ["subarg@1.0.0", "", { "dependencies": { "minimist": "^1.1.0" } }, "sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "synckit": ["synckit@0.11.12", "", { "dependencies": { "@pkgr/core": "^0.2.9" } }, "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ=="],
+
+    "syntax-error": ["syntax-error@1.4.0", "", { "dependencies": { "acorn-node": "^1.2.0" } }, "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w=="],
+
+    "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
+
+    "through2": ["through2@2.0.5", "", { "dependencies": { "readable-stream": "~2.3.6", "xtend": "~4.0.1" } }, "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ=="],
+
+    "timers-browserify": ["timers-browserify@1.4.2", "", { "dependencies": { "process": "~0.11.0" } }, "sha512-PIxwAupJZiYU4JmVZYwXp9FKsHMXb5h0ZEFyuXTAn8WLHOlcij+FEcbrvDsom1o5dr1YggEtFbECvGCW2sT53Q=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
+
+    "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
+
+    "to-buffer": ["to-buffer@1.2.2", "", { "dependencies": { "isarray": "^2.0.5", "safe-buffer": "^5.2.1", "typed-array-buffer": "^1.0.3" } }, "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "tsconfig": ["tsconfig@5.0.3", "", { "dependencies": { "any-promise": "^1.3.0", "parse-json": "^2.2.0", "strip-bom": "^2.0.0", "strip-json-comments": "^2.0.0" } }, "sha512-Cq65A3kVp6BbsUgg9DRHafaGmbMb9EhAc7fjWvudNWKjkbWrt43FnrtZt6awshH1R0ocfF2Z0uxock3lVqEgOg=="],
+
+    "tsify": ["tsify@5.0.4", "", { "dependencies": { "convert-source-map": "^1.1.0", "fs.realpath": "^1.0.0", "object-assign": "^4.1.0", "semver": "^6.1.0", "through2": "^2.0.0", "tsconfig": "^5.0.3" }, "peerDependencies": { "browserify": ">= 10.x", "typescript": ">= 2.8" } }, "sha512-XAZtQ5OMPsJFclkZ9xMZWkSNyMhMxEPsz3D2zu79yoKorH9j/DT4xCloJeXk5+cDhosEibu4bseMVjyPOAyLJA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tty-browserify": ["tty-browserify@0.0.1", "", {}, "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-fest": ["type-fest@0.8.1", "", {}, "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="],
+
+    "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
+
+    "typed-array-byte-length": ["typed-array-byte-length@1.0.3", "", { "dependencies": { "call-bind": "^1.0.8", "for-each": "^0.3.3", "gopd": "^1.2.0", "has-proto": "^1.2.0", "is-typed-array": "^1.1.14" } }, "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg=="],
+
+    "typed-array-byte-offset": ["typed-array-byte-offset@1.0.4", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "for-each": "^0.3.3", "gopd": "^1.2.0", "has-proto": "^1.2.0", "is-typed-array": "^1.1.15", "reflect.getprototypeof": "^1.0.9" } }, "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ=="],
+
+    "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
+
+    "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.59.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.1", "@typescript-eslint/parser": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1", "@typescript-eslint/utils": "8.59.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ=="],
+
+    "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
+
+    "umd": ["umd@3.0.3", "", { "bin": { "umd": "./bin/cli.js" } }, "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow=="],
+
+    "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
+
+    "undeclared-identifiers": ["undeclared-identifiers@1.1.3", "", { "dependencies": { "acorn-node": "^1.3.0", "dash-ast": "^1.0.0", "get-assigned-identifiers": "^1.2.0", "simple-concat": "^1.0.0", "xtend": "^4.0.1" }, "bin": { "undeclared-identifiers": "bin.js" } }, "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "url": ["url@0.11.4", "", { "dependencies": { "punycode": "^1.4.1", "qs": "^6.12.3" } }, "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg=="],
+
+    "util": ["util@0.12.5", "", { "dependencies": { "inherits": "^2.0.3", "is-arguments": "^1.0.4", "is-generator-function": "^1.0.7", "is-typed-array": "^1.1.3", "which-typed-array": "^1.1.2" } }, "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
+
+    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "vite-node": ["vite-node@2.1.9", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.7", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA=="],
+
+    "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
+
+    "vm-browserify": ["vm-browserify@1.1.2", "", {}, "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "which-boxed-primitive": ["which-boxed-primitive@1.1.1", "", { "dependencies": { "is-bigint": "^1.1.0", "is-boolean-object": "^1.2.1", "is-number-object": "^1.1.1", "is-string": "^1.1.1", "is-symbol": "^1.1.1" } }, "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA=="],
+
+    "which-builtin-type": ["which-builtin-type@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "function.prototype.name": "^1.1.6", "has-tostringtag": "^1.0.2", "is-async-function": "^2.0.0", "is-date-object": "^1.1.0", "is-finalizationregistry": "^1.1.0", "is-generator-function": "^1.0.10", "is-regex": "^1.2.1", "is-weakref": "^1.0.2", "isarray": "^2.0.5", "which-boxed-primitive": "^1.1.0", "which-collection": "^1.0.2", "which-typed-array": "^1.1.16" } }, "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q=="],
+
+    "which-collection": ["which-collection@1.0.2", "", { "dependencies": { "is-map": "^2.0.3", "is-set": "^2.0.3", "is-weakmap": "^2.0.2", "is-weakset": "^2.0.3" } }, "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw=="],
+
+    "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.1", "", { "dependencies": { "@typescript-eslint/types": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1" } }, "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg=="],
+
+    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils": ["@typescript-eslint/utils@8.59.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA=="],
+
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.1", "", { "dependencies": { "@typescript-eslint/types": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1" } }, "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg=="],
+
+    "@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@7.18.0", "", {}, "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ=="],
+
+    "@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@7.18.0", "", { "dependencies": { "@typescript-eslint/types": "7.18.0", "eslint-visitor-keys": "^3.4.3" } }, "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/utils": ["@typescript-eslint/utils@8.59.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@7.18.0", "", {}, "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@7.18.0", "", { "dependencies": { "@typescript-eslint/types": "7.18.0", "@typescript-eslint/visitor-keys": "7.18.0", "debug": "^4.3.4", "globby": "^11.1.0", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^1.3.0" } }, "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA=="],
+
+    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "acorn-node/acorn": ["acorn@7.4.1", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="],
+
+    "asn1.js/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
+    "assert/util": ["util@0.10.4", "", { "dependencies": { "inherits": "2.0.3" } }, "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A=="],
+
+    "clean-regexp/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
+    "combine-source-map/convert-source-map": ["convert-source-map@1.1.3", "", {}, "sha512-Y8L5rp6jo+g9VEPgvqNfEopjTR4OTYct8lXlS8iVQdmnjDvbdbzYe9rjtFCB9egC86JoNCU61WRY+ScjkZpnIg=="],
+
+    "create-ecdh/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
+    "diffie-hellman/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
+    "elliptic/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
+    "eslint-plugin-import-x/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "eslint-plugin-import-x/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "eslint-plugin-react/resolve": ["resolve@2.0.0-next.6", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA=="],
+
+    "eslint-plugin-unicorn/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "md5.js/hash-base": ["hash-base@3.1.2", "", { "dependencies": { "inherits": "^2.0.4", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.1" } }, "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "miller-rabin/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
+    "normalize-package-data/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
+
+    "public-encrypt/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
+    "read-pkg/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
+    "read-pkg/type-fest": ["type-fest@0.6.0", "", {}, "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="],
+
+    "read-pkg-up/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "regjsparser/jsesc": ["jsesc@0.5.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA=="],
+
+    "ripemd160/hash-base": ["hash-base@3.1.2", "", { "dependencies": { "inherits": "^2.0.4", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.1" } }, "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg=="],
+
+    "safe-array-concat/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
+    "safe-push-apply/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
+    "stream-browserify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "stream-http/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "to-buffer/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
+    "tsconfig/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "typescript-eslint/@typescript-eslint/utils": ["@typescript-eslint/utils@8.59.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA=="],
+
+    "uri-js/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "which-builtin-type/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
+    "@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.1", "", { "dependencies": { "@typescript-eslint/types": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1" } }, "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@7.18.0", "", { "dependencies": { "@typescript-eslint/types": "7.18.0", "eslint-visitor-keys": "^3.4.3" } }, "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/ts-api-utils": ["ts-api-utils@1.4.3", "", { "peerDependencies": { "typescript": ">=4.2.0" } }, "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw=="],
+
+    "assert/util/inherits": ["inherits@2.0.3", "", {}, "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="],
+
+    "eslint-plugin-import-x/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "read-pkg-up/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.1", "", { "dependencies": { "@typescript-eslint/types": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1" } }, "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
+    "eslint-plugin-import-x/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "read-pkg-up/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "read-pkg-up/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+  }
+}

--- a/demo/preferences-playground/index.html
+++ b/demo/preferences-playground/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OSM Preferences Playground</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/demo/preferences-playground/package.json
+++ b/demo/preferences-playground/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "preferences-playground",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "osm-api": "file:../..",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "vite": "^5.4.10"
+  }
+}

--- a/demo/preferences-playground/public/land.html
+++ b/demo/preferences-playground/public/land.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OSM Auth Landing</title>
+  </head>
+  <body>
+    <p>Completing OSM auth...</p>
+    <script>
+      if (new URLSearchParams(location.search).has("code")) {
+        new BroadcastChannel("osm-api-auth-complete").postMessage(location.href);
+        window.close();
+      }
+    </script>
+  </body>
+</html>

--- a/demo/preferences-playground/src/App.jsx
+++ b/demo/preferences-playground/src/App.jsx
@@ -1,0 +1,202 @@
+import React from "react";
+import { useEffect, useState } from "react";
+import * as OSM from "osm-api";
+import { AuthPanel } from "./components/AuthPanel";
+import { DataEditor } from "./components/DataEditor";
+import { LogPanel } from "./components/LogPanel";
+import { PreferenceActionsPanel } from "./components/PreferenceActionsPanel";
+import { ScenarioGuide } from "./components/ScenarioGuide";
+import { ServerPanel, getApiUrlForServer } from "./components/ServerPanel";
+import { StorageInspector } from "./components/StorageInspector";
+
+const SHORT_PRESET = JSON.stringify(
+  {
+    theme: "dark",
+    fontSize: 14,
+    items: ["a", "b", "c"],
+  },
+  null,
+  2,
+);
+
+const LONG_PRESET = JSON.stringify(
+  {
+    theme: "dark",
+    fontSize: 14,
+    items: Array.from({ length: 120 }, (_, i) => `item-${i}`),
+    note: "This payload is intentionally long to trigger split storage behavior.",
+  },
+  null,
+  2,
+);
+
+function createLogEntry(action, request, response, error) {
+  return {
+    id: `${Date.now()}-${Math.random()}`,
+    time: new Date().toLocaleTimeString(),
+    action,
+    request,
+    response,
+    error,
+    status: error ? "error" : "success",
+  };
+}
+
+function makeTokenPreview(token) {
+  if (!token) return "none";
+  if (token.length < 18) return token;
+  return `${token.slice(0, 8)}...${token.slice(-6)}`;
+}
+
+export function App() {
+  const [server, setServer] = useState("dev");
+  const [authMode, setAuthMode] = useState("popup");
+  const [clientId, setClientId] = useState("C4NEJIjmGvt2817yM7-0YUBTfmTI5Tx1M32WFoTwGTQ");
+  const [redirectUrl, setRedirectUrl] = useState("http://127.0.0.1:4317/land.html");
+  const [scopesText, setScopesText] = useState("read_prefs write_prefs");
+  const [switchUser, setSwitchUser] = useState(false);
+  const [authStatus, setAuthStatus] = useState({
+    loggedIn: false,
+    tokenPreview: "none",
+  });
+
+  const [demoKey, setDemoKey] = useState("my-key");
+  const [jsonValue, setJsonValue] = useState(SHORT_PRESET);
+  const [legacyValue, setLegacyValue] = useState("legacy-single-value");
+  const [getStorage, setGetStorage] = useState("auto");
+  const [updateStorage, setUpdateStorage] = useState("auto");
+  const [deleteStorage, setDeleteStorage] = useState("auto");
+
+  const [manualRootHashes, setManualRootHashes] = useState("deadbeef,facecafe");
+  const [manualChunkHash, setManualChunkHash] = useState("deadbeef");
+  const [manualChunkValue, setManualChunkValue] = useState("manual chunk value");
+
+  const [mergedSnapshot, setMergedSnapshot] = useState({});
+  const [rawSnapshot, setRawSnapshot] = useState({});
+  const [logs, setLogs] = useState([]);
+
+  function appendLog(action, request, response, error) {
+    setLogs((current) => [createLogEntry(action, request, response, error), ...current]);
+  }
+
+  function clearLogs() {
+    setLogs([]);
+  }
+
+  function loadShortPreset() {
+    setJsonValue(SHORT_PRESET);
+  }
+
+  function loadLongPreset() {
+    setJsonValue(LONG_PRESET);
+  }
+
+  async function refreshStorageSnapshot() {
+    try {
+      const merged = await OSM.getPreferences();
+      const raw = await OSM.getPreferences({ handleStorage: "raw" });
+      setMergedSnapshot(merged);
+      setRawSnapshot(raw);
+      appendLog("refreshStorageSnapshot", {}, { merged, raw });
+    } catch (error) {
+      const payload =
+        error instanceof Error
+          ? { name: error.name, message: error.message }
+          : { message: String(error) };
+      appendLog("refreshStorageSnapshot", {}, null, payload);
+    }
+  }
+
+  useEffect(function synchronizeAuthAndDefaultServer() {
+    OSM.configure({ apiUrl: getApiUrlForServer("dev") });
+    async function applyAuthReadyResult() {
+      await OSM.authReady;
+      const token = OSM.getAuthToken ? OSM.getAuthToken() : undefined;
+      setAuthStatus({
+        loggedIn: OSM.isLoggedIn(),
+        tokenPreview: makeTokenPreview(token),
+      });
+    }
+    applyAuthReadyResult();
+  }, []);
+
+  return (
+    <main style={{ fontFamily: "sans-serif", maxWidth: 1100, margin: "0 auto", padding: 12 }}>
+      <h1 style={{ marginTop: 0 }}>OSM Preferences Demo App</h1>
+      <p>
+        Commit-focused playground for preference APIs, including split storage, conflict behavior,
+        deprecated methods, and error simulations.
+      </p>
+
+      <ServerPanel server={server} onServerChange={setServer} onLog={appendLog} />
+
+      <AuthPanel
+        authMode={authMode}
+        clientId={clientId}
+        redirectUrl={redirectUrl}
+        scopesText={scopesText}
+        switchUser={switchUser}
+        onAuthModeChange={setAuthMode}
+        onClientIdChange={setClientId}
+        onRedirectUrlChange={setRedirectUrl}
+        onScopesTextChange={setScopesText}
+        onSwitchUserChange={setSwitchUser}
+        onAuthStatusChange={setAuthStatus}
+        onLog={appendLog}
+      />
+
+      <p style={{ marginTop: -4 }}>
+        Auth status: <strong>{authStatus.loggedIn ? "logged in" : "logged out"}</strong> | token:{" "}
+        <code>{authStatus.tokenPreview}</code>
+      </p>
+
+      <DataEditor
+        demoKey={demoKey}
+        jsonValue={jsonValue}
+        legacyValue={legacyValue}
+        getStorage={getStorage}
+        updateStorage={updateStorage}
+        deleteStorage={deleteStorage}
+        manualRootHashes={manualRootHashes}
+        manualChunkHash={manualChunkHash}
+        manualChunkValue={manualChunkValue}
+        onDemoKeyChange={setDemoKey}
+        onJsonValueChange={setJsonValue}
+        onLegacyValueChange={setLegacyValue}
+        onGetStorageChange={setGetStorage}
+        onUpdateStorageChange={setUpdateStorage}
+        onDeleteStorageChange={setDeleteStorage}
+        onManualRootHashesChange={setManualRootHashes}
+        onManualChunkHashChange={setManualChunkHash}
+        onManualChunkValueChange={setManualChunkValue}
+        onLoadShortPreset={loadShortPreset}
+        onLoadLongPreset={loadLongPreset}
+      />
+
+      <PreferenceActionsPanel
+        demoKey={demoKey}
+        jsonValue={jsonValue}
+        legacyValue={legacyValue}
+        getStorage={getStorage}
+        updateStorage={updateStorage}
+        deleteStorage={deleteStorage}
+        manualRootHashes={manualRootHashes}
+        manualChunkHash={manualChunkHash}
+        manualChunkValue={manualChunkValue}
+        onLog={appendLog}
+        onRefreshStorage={refreshStorageSnapshot}
+        onLoadShortPreset={loadShortPreset}
+        onLoadLongPreset={loadLongPreset}
+      />
+
+      <StorageInspector
+        mergedSnapshot={mergedSnapshot}
+        rawSnapshot={rawSnapshot}
+        onRefresh={refreshStorageSnapshot}
+      />
+
+      <ScenarioGuide />
+      <LogPanel logs={logs} onClear={clearLogs} />
+    </main>
+  );
+}

--- a/demo/preferences-playground/src/components/AuthPanel.jsx
+++ b/demo/preferences-playground/src/components/AuthPanel.jsx
@@ -1,0 +1,135 @@
+import React from "react";
+import * as OSM from "osm-api";
+
+function normalizeScopes(text) {
+  return text
+    .split(/[,\s]+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function tokenPreview(token) {
+  if (!token) return "none";
+  if (token.length < 18) return token;
+  return `${token.slice(0, 8)}...${token.slice(-6)}`;
+}
+
+export function AuthPanel({
+  authMode,
+  clientId,
+  redirectUrl,
+  scopesText,
+  switchUser,
+  onAuthModeChange,
+  onClientIdChange,
+  onRedirectUrlChange,
+  onScopesTextChange,
+  onSwitchUserChange,
+  onAuthStatusChange,
+  onLog,
+}) {
+  async function refreshAuthStatus() {
+    const token = OSM.getAuthToken ? OSM.getAuthToken() : undefined;
+    const state = {
+      loggedIn: OSM.isLoggedIn(),
+      tokenPreview: tokenPreview(token),
+    };
+    onAuthStatusChange(state);
+    onLog("authStatus", {}, state);
+  }
+
+  async function runLogin() {
+    const scopes = normalizeScopes(scopesText);
+    await OSM.login({
+      mode: authMode,
+      clientId,
+      redirectUrl,
+      scopes,
+      switchUser,
+    });
+    await refreshAuthStatus();
+  }
+
+  async function runLogout() {
+    OSM.logout();
+    await refreshAuthStatus();
+  }
+
+  async function waitForAuthReady() {
+    await OSM.authReady;
+    await refreshAuthStatus();
+  }
+
+  return (
+    <section style={{ border: "1px solid #bbb", padding: 12, marginBottom: 12 }}>
+      <h2 style={{ marginTop: 0 }}>2) Auth (library flow)</h2>
+      <p style={{ marginTop: 0 }}>
+        Uses <code>login</code>, <code>logout</code>, <code>isLoggedIn</code>, and{" "}
+        <code>authReady</code>.
+      </p>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 8 }}>
+        <label>
+          Mode:
+          <select
+            value={authMode}
+            onChange={(event) => onAuthModeChange(event.target.value)}
+            style={{ marginLeft: 8 }}
+          >
+            <option value="popup">popup</option>
+            <option value="redirect">redirect</option>
+          </select>
+        </label>
+
+        <label>
+          Client ID:
+          <input
+            value={clientId}
+            onChange={(event) => onClientIdChange(event.target.value)}
+            placeholder="Your OSM OAuth client id"
+            style={{ marginLeft: 8, width: 280 }}
+          />
+        </label>
+      </div>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 8 }}>
+        <label>
+          Redirect URL:
+          <input
+            value={redirectUrl}
+            onChange={(event) => onRedirectUrlChange(event.target.value)}
+            style={{ marginLeft: 8, width: 360 }}
+          />
+        </label>
+      </div>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 8 }}>
+        <label>
+          Scopes:
+          <input
+            value={scopesText}
+            onChange={(event) => onScopesTextChange(event.target.value)}
+            style={{ marginLeft: 8, width: 360 }}
+          />
+        </label>
+
+        <label>
+          <input
+            type="checkbox"
+            checked={switchUser}
+            onChange={(event) => onSwitchUserChange(event.target.checked)}
+            style={{ marginRight: 6 }}
+          />
+          switchUser
+        </label>
+      </div>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <button onClick={() => runLogin()}>Login</button>
+        <button onClick={() => runLogout()}>Logout</button>
+        <button onClick={() => refreshAuthStatus()}>Refresh auth status</button>
+        <button onClick={() => waitForAuthReady()}>Await authReady</button>
+      </div>
+    </section>
+  );
+}

--- a/demo/preferences-playground/src/components/DataEditor.jsx
+++ b/demo/preferences-playground/src/components/DataEditor.jsx
@@ -1,0 +1,137 @@
+import React from "react";
+
+export function DataEditor({
+  demoKey,
+  jsonValue,
+  legacyValue,
+  getStorage,
+  updateStorage,
+  deleteStorage,
+  manualRootHashes,
+  manualChunkHash,
+  manualChunkValue,
+  onDemoKeyChange,
+  onJsonValueChange,
+  onLegacyValueChange,
+  onGetStorageChange,
+  onUpdateStorageChange,
+  onDeleteStorageChange,
+  onManualRootHashesChange,
+  onManualChunkHashChange,
+  onManualChunkValueChange,
+  onLoadShortPreset,
+  onLoadLongPreset,
+}) {
+  return (
+    <section style={{ border: "1px solid #bbb", padding: 12, marginBottom: 12 }}>
+      <h2 style={{ marginTop: 0 }}>3) Demo Data</h2>
+      <p style={{ marginTop: 0 }}>Edit key/value and storage options before running actions.</p>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 8 }}>
+        <label>
+          Logical key:
+          <input
+            value={demoKey}
+            onChange={(event) => onDemoKeyChange(event.target.value)}
+            style={{ marginLeft: 8, width: 280 }}
+          />
+        </label>
+        <label>
+          Legacy raw value:
+          <input
+            value={legacyValue}
+            onChange={(event) => onLegacyValueChange(event.target.value)}
+            style={{ marginLeft: 8, width: 280 }}
+          />
+        </label>
+      </div>
+
+      <div style={{ marginBottom: 8 }}>
+        <label>
+          JSON for updatePreference:
+          <textarea
+            value={jsonValue}
+            onChange={(event) => onJsonValueChange(event.target.value)}
+            style={{ display: "block", width: "100%", minHeight: 120, marginTop: 6 }}
+          />
+        </label>
+      </div>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 8 }}>
+        <button onClick={onLoadShortPreset}>Load short preset</button>
+        <button onClick={onLoadLongPreset}>Load long preset</button>
+      </div>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 8 }}>
+        <label>
+          getPreference storage:
+          <select
+            value={getStorage}
+            onChange={(event) => onGetStorageChange(event.target.value)}
+            style={{ marginLeft: 8 }}
+          >
+            <option value="auto">auto</option>
+            <option value="single">single</option>
+            <option value="split">split</option>
+          </select>
+        </label>
+
+        <label>
+          updatePreference storage:
+          <select
+            value={updateStorage}
+            onChange={(event) => onUpdateStorageChange(event.target.value)}
+            style={{ marginLeft: 8 }}
+          >
+            <option value="auto">auto</option>
+            <option value="single">single</option>
+            <option value="split">split</option>
+          </select>
+        </label>
+
+        <label>
+          deletePreference storage:
+          <select
+            value={deleteStorage}
+            onChange={(event) => onDeleteStorageChange(event.target.value)}
+            style={{ marginLeft: 8 }}
+          >
+            <option value="auto">auto</option>
+            <option value="single">single</option>
+            <option value="split">split</option>
+          </select>
+        </label>
+      </div>
+
+      <h3>Manual split corruption fields</h3>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 8 }}>
+        <label>
+          Root hashes:
+          <input
+            value={manualRootHashes}
+            onChange={(event) => onManualRootHashesChange(event.target.value)}
+            style={{ marginLeft: 8, width: 240 }}
+          />
+        </label>
+        <label>
+          Chunk hash:
+          <input
+            value={manualChunkHash}
+            onChange={(event) => onManualChunkHashChange(event.target.value)}
+            style={{ marginLeft: 8, width: 160 }}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Chunk value:
+          <textarea
+            value={manualChunkValue}
+            onChange={(event) => onManualChunkValueChange(event.target.value)}
+            style={{ display: "block", width: "100%", minHeight: 80, marginTop: 6 }}
+          />
+        </label>
+      </div>
+    </section>
+  );
+}

--- a/demo/preferences-playground/src/components/LogPanel.jsx
+++ b/demo/preferences-playground/src/components/LogPanel.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+export function LogPanel({ logs, onClear }) {
+  return (
+    <section style={{ border: "1px solid #bbb", padding: 12, marginBottom: 12 }}>
+      <h2 style={{ marginTop: 0 }}>6) Request/Response Log</h2>
+      <button onClick={onClear}>Clear log</button>
+      <div style={{ marginTop: 12 }}>
+        {logs.length === 0 ? (
+          <p>No entries yet.</p>
+        ) : (
+          logs.map((entry) => (
+            <div key={entry.id} style={{ border: "1px solid #ddd", padding: 8, marginBottom: 8 }}>
+              <div>
+                <strong>{entry.action}</strong> - {entry.status} - {entry.time}
+              </div>
+              <pre style={{ marginBottom: 6, overflowX: "auto" }}>
+                request: {JSON.stringify(entry.request, null, 2)}
+              </pre>
+              {entry.status === "success" ? (
+                <pre style={{ marginBottom: 0, overflowX: "auto" }}>
+                  response: {JSON.stringify(entry.response, null, 2)}
+                </pre>
+              ) : (
+                <pre style={{ marginBottom: 0, overflowX: "auto" }}>
+                  error: {JSON.stringify(entry.error, null, 2)}
+                </pre>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/demo/preferences-playground/src/components/PreferenceActionsPanel.jsx
+++ b/demo/preferences-playground/src/components/PreferenceActionsPanel.jsx
@@ -1,0 +1,326 @@
+import React from "react";
+import * as OSM from "osm-api";
+
+function toErrorPayload(error) {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message };
+  }
+  return { message: String(error) };
+}
+
+function createDemoSchema() {
+  return {
+    "~standard": {
+      version: 1,
+      vendor: "preferences-playground",
+      validate(value) {
+        const issues = [];
+        if (!value || typeof value !== "object" || Array.isArray(value)) {
+          return { issues: [{ message: "Expected object" }] };
+        }
+        if (typeof value.theme !== "string") {
+          issues.push({ message: "theme must be a string" });
+        }
+        if (typeof value.fontSize !== "number") {
+          issues.push({ message: "fontSize must be a number" });
+        }
+        if (issues.length > 0) return { issues };
+        return { value };
+      },
+    },
+  };
+}
+
+export function PreferenceActionsPanel({
+  demoKey,
+  jsonValue,
+  legacyValue,
+  getStorage,
+  updateStorage,
+  deleteStorage,
+  manualRootHashes,
+  manualChunkHash,
+  manualChunkValue,
+  onLog,
+  onRefreshStorage,
+  onLoadShortPreset,
+  onLoadLongPreset,
+}) {
+  async function runAction(action, request, operation) {
+    try {
+      const response = await operation();
+      onLog(action, request, response);
+      return response;
+    } catch (error) {
+      onLog(action, request, null, toErrorPayload(error));
+      return null;
+    }
+  }
+
+  async function actionGetPreferencesMerged() {
+    await runAction("getPreferences(merged)", {}, async () => await OSM.getPreferences());
+  }
+
+  async function actionGetPreferencesRaw() {
+    await runAction(
+      "getPreferences(raw)",
+      { handleStorage: "raw" },
+      async () => await OSM.getPreferences({ handleStorage: "raw" }),
+    );
+  }
+
+  async function actionGetPreference() {
+    await runAction(
+      "getPreference",
+      { key: demoKey, storage: getStorage },
+      async () => await OSM.getPreference(demoKey, { storage: getStorage }),
+    );
+  }
+
+  async function actionGetPreferenceWithSchema() {
+    const schema = createDemoSchema();
+    await runAction(
+      "getPreference(schema)",
+      { key: demoKey, storage: getStorage, schema: "demoSchema" },
+      async () => await OSM.getPreference(demoKey, { storage: getStorage, schema }),
+    );
+  }
+
+  async function actionUpdatePreference() {
+    const parsedValue = JSON.parse(jsonValue);
+    await runAction(
+      "updatePreference",
+      { key: demoKey, storage: updateStorage, value: parsedValue },
+      async () => await OSM.updatePreference(demoKey, parsedValue, { storage: updateStorage }),
+    );
+  }
+
+  async function actionDeletePreference() {
+    await runAction(
+      "deletePreference",
+      { key: demoKey, storage: deleteStorage },
+      async () => await OSM.deletePreference(demoKey, { storage: deleteStorage }),
+    );
+  }
+
+  async function actionUpdatePreferencesDeprecated() {
+    await runAction(
+      "updatePreferences(deprecated)",
+      { key: demoKey, value: legacyValue },
+      async () => await OSM.updatePreferences(demoKey, legacyValue),
+    );
+  }
+
+  async function actionDeletePreferencesDeprecated() {
+    await runAction(
+      "deletePreferences(deprecated)",
+      { key: demoKey },
+      async () => await OSM.deletePreferences(demoKey),
+    );
+  }
+
+  async function actionInvalidKeyError() {
+    await runAction(
+      "invalidKeyTest",
+      { key: `${demoKey}/bad` },
+      async () => await OSM.getPreference(`${demoKey}/bad`),
+    );
+  }
+
+  async function actionMalformedJsonAndSchema() {
+    await runAction(
+      "writeMalformedJsonViaDeprecated",
+      { key: demoKey, value: "{not-json}" },
+      async () => await OSM.updatePreferences(demoKey, "{not-json}"),
+    );
+    await actionGetPreferenceWithSchema();
+  }
+
+  async function actionSingleOverflowError() {
+    const tooLong = "x".repeat(300);
+    await runAction(
+      "singleOverflowTest",
+      { key: demoKey, storage: "single", length: tooLong.length },
+      async () => await OSM.updatePreference(demoKey, tooLong, { storage: "single" }),
+    );
+  }
+
+  async function actionSimulateBrokenRoot() {
+    await runAction(
+      "manualSetRoot",
+      { key: `${demoKey}:root`, value: manualRootHashes },
+      async () => await OSM.updatePreferences(`${demoKey}:root`, manualRootHashes),
+    );
+  }
+
+  async function actionSimulateOrphanChunk() {
+    await runAction(
+      "manualSetChunk",
+      { key: `${demoKey}:${manualChunkHash}`, value: manualChunkValue },
+      async () => await OSM.updatePreferences(`${demoKey}:${manualChunkHash}`, manualChunkValue),
+    );
+  }
+
+  async function actionDeleteManualChunk() {
+    await runAction(
+      "manualDeleteChunk",
+      { key: `${demoKey}:${manualChunkHash}` },
+      async () => await OSM.deletePreferences(`${demoKey}:${manualChunkHash}`),
+    );
+  }
+
+  async function actionDeleteManualRoot() {
+    await runAction(
+      "manualDeleteRoot",
+      { key: `${demoKey}:root` },
+      async () => await OSM.deletePreferences(`${demoKey}:root`),
+    );
+  }
+
+  async function runScenarioBaseline() {
+    onLoadShortPreset();
+    await runAction("scenario:baseline:load-short", {}, async () => "loaded short preset");
+    const parsed = JSON.parse('{"theme":"dark","fontSize":14,"items":["a","b"]}');
+    await runAction(
+      "scenario:baseline:update-single",
+      { key: demoKey, storage: "single", value: parsed },
+      async () => await OSM.updatePreference(demoKey, parsed, { storage: "single" }),
+    );
+    await runAction(
+      "scenario:baseline:get-single",
+      { key: demoKey, storage: "single" },
+      async () => await OSM.getPreference(demoKey, { storage: "single" }),
+    );
+    await onRefreshStorage();
+  }
+
+  async function runScenarioSplit() {
+    onLoadLongPreset();
+    await runAction("scenario:split:load-long", {}, async () => "loaded long preset");
+    const longValue = {
+      theme: "dark",
+      fontSize: 14,
+      items: Array.from({ length: 120 }, (_, i) => `item-${i}`),
+      note: "long payload for split storage demo",
+    };
+    await runAction(
+      "scenario:split:update-split",
+      { key: demoKey, storage: "split" },
+      async () => await OSM.updatePreference(demoKey, longValue, { storage: "split" }),
+    );
+    await runAction(
+      "scenario:split:get-split",
+      { key: demoKey, storage: "split" },
+      async () => await OSM.getPreference(demoKey, { storage: "split" }),
+    );
+    await runAction(
+      "scenario:split:get-raw",
+      { handleStorage: "raw" },
+      async () => await OSM.getPreferences({ handleStorage: "raw" }),
+    );
+    await onRefreshStorage();
+  }
+
+  async function runScenarioConflict() {
+    const longValue = {
+      theme: "conflict",
+      fontSize: 16,
+      items: Array.from({ length: 120 }, (_, i) => `conflict-${i}`),
+    };
+    await runAction(
+      "scenario:conflict:ensure-split",
+      { key: demoKey },
+      async () => await OSM.updatePreference(demoKey, longValue, { storage: "split" }),
+    );
+    await runAction(
+      "scenario:conflict:add-single-deprecated",
+      { key: demoKey, value: legacyValue },
+      async () => await OSM.updatePreferences(demoKey, legacyValue),
+    );
+    await runAction(
+      "scenario:conflict:get-auto-expected-error",
+      { key: demoKey, storage: "auto" },
+      async () => await OSM.getPreference(demoKey, { storage: "auto" }),
+    );
+    await runAction(
+      "scenario:conflict:update-auto-expected-error",
+      { key: demoKey, storage: "auto" },
+      async () =>
+        await OSM.updatePreference(demoKey, { theme: "x", fontSize: 12 }, { storage: "auto" }),
+    );
+  }
+
+  async function runScenarioCleanup() {
+    await runAction(
+      "scenario:cleanup:delete-single",
+      { key: demoKey, storage: "single" },
+      async () => await OSM.deletePreference(demoKey, { storage: "single" }),
+    );
+    await runAction(
+      "scenario:cleanup:get-auto",
+      { key: demoKey, storage: "auto" },
+      async () => await OSM.getPreference(demoKey, { storage: "auto" }),
+    );
+    await runAction(
+      "scenario:cleanup:update-auto",
+      { key: demoKey, storage: "auto" },
+      async () =>
+        await OSM.updatePreference(demoKey, { theme: "clean", fontSize: 18 }, { storage: "auto" }),
+    );
+    await onRefreshStorage();
+  }
+
+  return (
+    <section style={{ border: "1px solid #bbb", padding: 12, marginBottom: 12 }}>
+      <h2 style={{ marginTop: 0 }}>4) Example Actions</h2>
+      <p style={{ marginTop: 0 }}>
+        Run actions from the updated preference examples and inspect outputs in the log.
+      </p>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 12 }}>
+        <button onClick={() => actionGetPreferencesMerged()}>getPreferences (merged)</button>
+        <button onClick={() => actionGetPreferencesRaw()}>getPreferences (raw)</button>
+        <button onClick={() => actionGetPreference()}>getPreference</button>
+        <button onClick={() => actionGetPreferenceWithSchema()}>getPreference with schema</button>
+        <button onClick={() => actionUpdatePreference()}>updatePreference</button>
+        <button onClick={() => actionDeletePreference()}>deletePreference</button>
+        <button onClick={() => actionUpdatePreferencesDeprecated()}>
+          updatePreferences (deprecated)
+        </button>
+        <button onClick={() => actionDeletePreferencesDeprecated()}>
+          deletePreferences (deprecated)
+        </button>
+      </div>
+
+      <h3>Scenario one-click runs</h3>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 12 }}>
+        <button onClick={() => runScenarioBaseline()}>Run baseline scenario</button>
+        <button onClick={() => runScenarioSplit()}>Run split scenario</button>
+        <button onClick={() => runScenarioConflict()}>Run conflict scenario</button>
+        <button onClick={() => runScenarioCleanup()}>Run cleanup scenario</button>
+      </div>
+
+      <h3>Error-case tests</h3>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 12 }}>
+        <button onClick={() => actionInvalidKeyError()}>Invalid key chars</button>
+        <button onClick={() => actionMalformedJsonAndSchema()}>
+          Malformed JSON + schema issues
+        </button>
+        <button onClick={() => actionSingleOverflowError()}>Single overflow (&gt;255 chars)</button>
+      </div>
+
+      <h3>Manual split corruption tools</h3>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 8 }}>
+        <button onClick={() => actionSimulateBrokenRoot()}>Set root with hashes (manual)</button>
+        <button onClick={() => actionSimulateOrphanChunk()}>Set chunk key (manual)</button>
+        <button onClick={() => actionDeleteManualChunk()}>Delete chunk key (manual)</button>
+        <button onClick={() => actionDeleteManualRoot()}>Delete root key (manual)</button>
+        <button onClick={() => onRefreshStorage()}>Refresh after manual edits</button>
+      </div>
+
+      <p style={{ marginBottom: 0 }}>
+        Split max payload characters: <code>{OSM.PREFERENCE_SPLIT_MAX_PAYLOAD_BYTES}</code>
+      </p>
+    </section>
+  );
+}

--- a/demo/preferences-playground/src/components/ScenarioGuide.jsx
+++ b/demo/preferences-playground/src/components/ScenarioGuide.jsx
@@ -1,0 +1,108 @@
+import React from "react";
+
+const EXAMPLE_LINKS = [
+  ["getPreferences", "https://github.com/osmlab/osm-api-js/blob/main/examples/getPreferences.md"],
+  ["getPreference", "https://github.com/osmlab/osm-api-js/blob/main/examples/getPreference.md"],
+  [
+    "updatePreference",
+    "https://github.com/osmlab/osm-api-js/blob/main/examples/updatePreference.md",
+  ],
+  [
+    "deletePreference",
+    "https://github.com/osmlab/osm-api-js/blob/main/examples/deletePreference.md",
+  ],
+  [
+    "updatePreferences (deprecated)",
+    "https://github.com/osmlab/osm-api-js/blob/main/examples/updatePreferences.md",
+  ],
+  [
+    "deletePreferences (deprecated)",
+    "https://github.com/osmlab/osm-api-js/blob/main/examples/deletePreferences.md",
+  ],
+  ["dev-server", "https://github.com/osmlab/osm-api-js/blob/main/examples/dev-server.md"],
+];
+
+const SOURCE_LINKS = [
+  [
+    "getPreferences.ts",
+    "https://github.com/osmlab/osm-api-js/blob/main/src/api/preferences/getPreferences.ts",
+  ],
+  [
+    "getPreference.ts",
+    "https://github.com/osmlab/osm-api-js/blob/main/src/api/preferences/getPreference.ts",
+  ],
+  [
+    "updatePreference.ts",
+    "https://github.com/osmlab/osm-api-js/blob/main/src/api/preferences/updatePreference.ts",
+  ],
+  [
+    "deletePreference.ts",
+    "https://github.com/osmlab/osm-api-js/blob/main/src/api/preferences/deletePreference.ts",
+  ],
+  ["chunked.ts", "https://github.com/osmlab/osm-api-js/blob/main/src/api/preferences/chunked.ts"],
+];
+
+export function ScenarioGuide() {
+  return (
+    <section style={{ border: "1px solid #bbb", padding: 12, marginBottom: 12 }}>
+      <h2 style={{ marginTop: 0 }}>5) What to test and see</h2>
+      <p style={{ marginTop: 0 }}>
+        Use these guided flows to reproduce commit-specific preference behavior.
+      </p>
+
+      <h3>Step-by-step scenarios</h3>
+      <ol>
+        <li>
+          Baseline single write/read: click <code>Run baseline scenario</code> in Example Actions.
+          <div>Expected: single value is readable with storage=single.</div>
+        </li>
+        <li>
+          Split write/read: click <code>Run split scenario</code>.
+          <div>Expected: root + chunks in raw storage, split read succeeds.</div>
+        </li>
+        <li>
+          Auto conflict: click <code>Run conflict scenario</code>.
+          <div>
+            Expected: when both single and split exist, auto read/update throw conflict errors.
+          </div>
+        </li>
+        <li>
+          Cleanup: click <code>Run cleanup scenario</code>.
+          <div>
+            Expected: explicit storage cleanup resolves conflict, then auto calls work again.
+          </div>
+        </li>
+      </ol>
+
+      <h3>Error simulation helpers</h3>
+      <ul>
+        <li>Invalid key chars test (`/ ? # \\`).</li>
+        <li>Malformed JSON + schema issues test.</li>
+        <li>Single-storage overflow test (&gt;255 chars serialized).</li>
+        <li>Manual broken root/chunk simulation controls.</li>
+      </ul>
+
+      <h3>Example docs</h3>
+      <ul>
+        {EXAMPLE_LINKS.map(([label, url]) => (
+          <li key={label}>
+            <a href={url} target="_blank" rel="noreferrer">
+              {label}
+            </a>
+          </li>
+        ))}
+      </ul>
+
+      <h3>Source links</h3>
+      <ul>
+        {SOURCE_LINKS.map(([label, url]) => (
+          <li key={label}>
+            <a href={url} target="_blank" rel="noreferrer">
+              {label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/demo/preferences-playground/src/components/ServerPanel.jsx
+++ b/demo/preferences-playground/src/components/ServerPanel.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import * as OSM from "osm-api";
+
+const DEV_API_URL = "https://master.apis.dev.openstreetmap.org";
+const LIVE_API_URL = "https://api.openstreetmap.org";
+
+export function getApiUrlForServer(server) {
+  return server === "live" ? LIVE_API_URL : DEV_API_URL;
+}
+
+export function ServerPanel({ server, onServerChange, onLog }) {
+  function applyServer(nextServer) {
+    const apiUrl = getApiUrlForServer(nextServer);
+    OSM.configure({ apiUrl });
+    onServerChange(nextServer);
+    onLog("configure", { apiUrl }, { ok: true });
+  }
+
+  return (
+    <section style={{ border: "1px solid #bbb", padding: 12, marginBottom: 12 }}>
+      <h2 style={{ marginTop: 0 }}>1) Environment</h2>
+      <p style={{ marginTop: 0 }}>
+        Toggle between development and live OSM API servers. Default is dev.
+      </p>
+      <label>
+        Server:
+        <select
+          value={server}
+          onChange={(event) => applyServer(event.target.value)}
+          style={{ marginLeft: 8 }}
+        >
+          <option value="dev">dev (default)</option>
+          <option value="live">live</option>
+        </select>
+      </label>
+      <p style={{ marginBottom: 0 }}>
+        Active apiUrl: <code>{getApiUrlForServer(server)}</code>
+      </p>
+    </section>
+  );
+}

--- a/demo/preferences-playground/src/components/StorageInspector.jsx
+++ b/demo/preferences-playground/src/components/StorageInspector.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+export function StorageInspector({ rawSnapshot, mergedSnapshot, onRefresh }) {
+  return (
+    <section style={{ border: "1px solid #bbb", padding: 12, marginBottom: 12 }}>
+      <h2 style={{ marginTop: 0 }}>4) Storage Inspector</h2>
+      <p style={{ marginTop: 0 }}>
+        Refreshes both <code>getPreferences()</code> (merged) and{" "}
+        <code>getPreferences(&#123; handleStorage: "raw" &#125;)</code>.
+      </p>
+      <button onClick={onRefresh}>Refresh storage snapshot</button>
+      <div style={{ display: "flex", gap: 12, marginTop: 12, flexWrap: "wrap" }}>
+        <div style={{ flex: "1 1 420px" }}>
+          <h3 style={{ margin: "8px 0" }}>Merged (default)</h3>
+          <pre
+            style={{
+              border: "1px solid #ddd",
+              padding: 8,
+              margin: 0,
+              overflowX: "auto",
+            }}
+          >
+            {JSON.stringify(mergedSnapshot, null, 2)}
+          </pre>
+        </div>
+        <div style={{ flex: "1 1 420px" }}>
+          <h3 style={{ margin: "8px 0" }}>Raw</h3>
+          <pre
+            style={{
+              border: "1px solid #ddd",
+              padding: 8,
+              margin: 0,
+              overflowX: "auto",
+            }}
+          >
+            {JSON.stringify(rawSnapshot, null, 2)}
+          </pre>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/demo/preferences-playground/src/main.jsx
+++ b/demo/preferences-playground/src/main.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+
+createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/demo/preferences-playground/vite.config.js
+++ b/demo/preferences-playground/vite.config.js
@@ -1,0 +1,19 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default defineConfig({
+  server: {
+    host: "127.0.0.1",
+    port: 4317,
+    strictPort: true,
+  },
+  resolve: {
+    alias: {
+      "osm-api": path.resolve(__dirname, "../../src/index.ts"),
+    },
+  },
+});

--- a/examples/deletePreference.md
+++ b/examples/deletePreference.md
@@ -1,0 +1,67 @@
+# deletePreference
+
+Removes one preference by key. What gets deleted depends on `storage`.
+
+## Split keys
+
+See [Split storage](updatePreference.md#split-storage) for how split keys look.
+
+## Example
+
+### Database state
+
+Lets assume the OSM DB has the following data in the user's preferences:
+
+```yaml
+# Single key
+my-key=foobar
+
+# Split key
+my-key:root=a1b2c3d4,e5f6g7h8
+my-key:a1b2c3d4={"theme":"dark","fontSize":14,"items":["a","b","c",
+my-key:e5f6g7h8="d","e"]}
+```
+
+### Delete with `storage: auto`
+
+`auto` is the default `storage`. It will delete both my-key and my-key:root + chunks.
+In our example all four DB entries will be removed.
+
+```ts
+import { deletePreference } from "osm-api";
+
+await deletePreference("my-key");
+// or…
+await deletePreference("my-key", { storage: "auto" });
+// → void
+```
+
+### Delete with `storage: single`
+
+`single` deletes only the specific key provided. The split keys are ignored.
+In our example only the first DB entry will be removed.
+
+```ts
+import { deletePreference } from "osm-api";
+
+await deletePreference("my-key", { storage: "single" });
+// → void
+```
+
+### Delete with `storage: split`
+
+`split` deletes only the split keys (root + chunks). The single key is ignored.
+In our example only the three `my-key:*` DB entries will be removed.
+
+```ts
+import { deletePreference } from "osm-api";
+
+await deletePreference("my-key", { storage: "split" });
+// → void
+```
+
+## Error cases
+
+- **Invalid key:** If the key contains `/`, `?`, `#`, or `\` → **throws** (see [Key format](updatePreference.md#key-format)).
+- **Network / auth:** If the request fails (e.g. no auth, API down), the underlying fetch throws; no preferences are changed.
+- No conflict error: unlike `getPreference`, delete does not throw when both single and split exist; with `auto` it deletes both.

--- a/examples/deletePreferences.md
+++ b/examples/deletePreferences.md
@@ -1,11 +1,34 @@
 # deletePreferences
 
+**Deprecated.** Removes only the single API key; equivalent to `deletePreference(key, { storage: 'single' })`. Split-stored keys (e.g. `key:root`, `key:hash`) are unchanged. Prefer `deletePreference(key)` with `storage: 'auto'` to remove both single and split, or `deletePreference(key, { storage: 'single' })` for single-key only. Returns `void`.
+
+## Split keys
+
+See [Split storage](updatePreference.md#split-storage).
+
+## Example
+
+### Database state
+
+Lets assume the OSM DB has the following data in the user's preferences:
+
+```yaml
+# Single key
+my-key=foobar
+
+# Split key
+my-key:root=a1b2c3d4,e5f6g7h8
+my-key:a1b2c3d4={"theme":"dark","fontSize":14,"items":["a","b","c",
+my-key:e5f6g7h8="d","e"]}
+```
+
+### Delete (single key only)
+
+Removes only the single API key. With the example DB, `deletePreferences("my-key")` removes `my-key=foobar`; `my-key:root` and chunks stay.
+
 ```ts
 import { deletePreferences } from "osm-api";
 
-await deletePreferences("key");
+await deletePreferences("my-key");
+// → void
 ```
-
-Response:
-
-_none_

--- a/examples/getPreference.md
+++ b/examples/getPreference.md
@@ -1,0 +1,152 @@
+# getPreference
+
+Gets one preference by key. What you get depends on `storage`. Returns `string | null` (no schema) or `PreferenceResult<T>` (with schema).
+
+## Split keys
+
+See [Split storage](updatePreference.md#split-storage) for how split keys look.
+
+## Schema and types
+
+> [!NOTE]
+> Prefer using `getPreference` with a runtime validation schema (e.g. [Zod](https://zod.dev)) so you get typed, validated data and clear parse/validation errors.
+
+See [Schema and types](updatePreference.md#schema-and-types).
+
+## Examples
+
+### Database state
+
+Assume the OSM DB has the following data in the user's preferences:
+
+```yaml
+# Single key
+my-key=foobar
+
+# Split key
+my-key:root=a1b2c3d4,e5f6g7h8
+my-key:a1b2c3d4={"theme":"dark","fontSize":14,"items":["a","b","c",
+my-key:e5f6g7h8="d","e"]}
+```
+
+### Get with `storage: auto`
+
+`auto` is the default. It looks for both single and split; if only one form exists, returns its value. If **both** exist for the same key it **throws** (use `storage: 'single'` or `'split'` to resolve). If neither exists, returns `null`.
+
+With the example DB state above, `my-key` exists as both single and split, so the following **throws**. Use `storage: 'single'` or `'split'` (below) to read.
+
+```ts
+import { getPreference } from "osm-api";
+
+// With example DB state (both present) this throws:
+await getPreference("my-key");
+// or…
+await getPreference("my-key", { storage: "auto" });
+// → throws  Use storage: 'single' or 'split' to get a value.
+```
+
+Example when only one storage form is present (e.g. after deleting the single key so only split remains):
+
+```ts
+import { deletePreference, getPreference } from "osm-api";
+
+// With example DB state (both present): remove single key so only split remains
+await deletePreference("my-key", { storage: "single" });
+// Now only the split keys (root + chunks) are present
+const value = await getPreference("my-key", { storage: "auto" });
+// → string | null
+console.log(value);
+// With example DB: '{"theme":"dark","fontSize":14,"items":["a","b","c","d","e"]}'
+```
+
+### Get with `storage: single`
+
+Reads only the single API key. Split keys are ignored. With the example DB state this returns the single key’s value.
+
+```ts
+const value = await getPreference("my-key", { storage: "single" });
+// → string | null
+console.log(value);
+// With example DB: "foobar"
+```
+
+### Get with `storage: split`
+
+Reads only split storage (root + chunks). Single key is ignored. With the example DB state this returns the concatenated split value.
+
+```ts
+const value = await getPreference("my-key", { storage: "split" });
+// → string | null
+console.log(value);
+// With example DB: '{"theme":"dark","fontSize":14,"items":["a","b","c","d","e"]}'
+```
+
+### Usage without schema – returns string
+
+Return type is `string | null`. With the example DB state use `storage: 'single'` or `'split'` (auto would throw).
+
+```ts
+// Single key: returns "foobar" with example DB
+const value = await getPreference("my-key", { storage: "single" });
+// or getPreference("my-key", { storage: "split" }) for the concatenated JSON string
+// → string | null
+console.log(value);
+// With example DB (single): "foobar"  or  (split): '{"theme":"dark","fontSize":14,"items":["a","b","c","d","e"]}'
+```
+
+### Usage with schema – typed and validated return value
+
+Return type is `PreferenceResult<T>` (`{ value }` | `{ issues }` | `null`). With the example DB state use `storage: 'split'` so the concatenated JSON is parsed and validated.
+
+```ts
+import { getPreference } from "osm-api";
+import { z } from "zod";
+
+const schema = z.object({
+  theme: z.string(),
+  fontSize: z.number(),
+  items: z.array(z.string()),
+});
+const result = await getPreference("my-key", { schema, storage: "split" });
+// → PreferenceResult<{ theme: string; fontSize: number; items: string[] }>
+
+if (result === null) {
+  console.log(null); // not set or missing chunk
+} else if ("issues" in result) {
+  console.log(result.issues); // parse or validation failed
+} else {
+  console.log(result.value);
+  // With example DB: { theme: "dark", fontSize: 14, items: ["a", "b", "c", "d", "e"] }
+}
+```
+
+### Root and chunks out of sync (`storage: split`)
+
+When using `storage: 'split'` or `'auto'`, the value is read from the root manifest plus chunk keys. Preferences are fetched in **one request** (`getPreferences`); there are no per-chunk network calls.
+
+- **Chunk key missing:** The chunk key is not in the returned map (never written, or deleted, or from a failed write). `unpackChunkedRaw` sees the key as `undefined` and returns `null`. So “root present but chunk missing” → `null` (same as key not present).
+- **Network error:** If the single `getPreferences()` call fails (network/auth), it **throws**. There is no “network error for a chunk” — you either get the full map or the call fails.
+
+So “out of sync” (root present, one or more chunks missing) and “key not present” both yield `null`; only a failed fetch throws.
+
+```ts
+// Example: root exists, one chunk missing (e.g. failed split write)
+// DB: my-key:root=a1b2c3d4,e5f6g7h8   my-key:a1b2c3d4="first 255 chars"  (my-key:e5f6g7h8 missing)
+const value = await getPreference("my-key", { storage: "split" });
+// → null  (missing chunk; same as key not present)
+```
+
+Orphan roots (root present, chunks missing) and orphan chunks (chunks with no or different root) are **not** auto-deleted by `getPreference`. A later successful `updatePreference` with split storage deletes old chunks from the previous root and any orphan chunk keys for that prefix; see [Cleanup](#cleanup) below.
+
+## Error cases
+
+- **Invalid key:** If the key contains `/`, `?`, `#`, or `\` → **throws** (see [Key format](updatePreference.md#key-format)).
+- **Key not present:** Returns `null` (no throw). Same for missing root/chunk when using `storage: 'split'` or `'auto'`.
+- **Root present, chunk missing (out of sync):** Returns `null` (no throw). See [Root and chunks out of sync](#root-and-chunks-out-of-sync-split-storage) above.
+- **Conflict (auto only):** The key exists as **both** a single key and split storage → **throws** with a message; retry with `storage: 'single'` or `storage: 'split'`.
+- **With schema:** Stored value is invalid JSON or fails validation → returns `{ issues: [...] }` (no throw). Use `"issues" in result` to detect.
+
+## Cleanup
+
+- **Orphan roots** (root present, one or more chunks missing): Not auto-deleted. `getPreference` returns `null`. To remove the orphan root and any remaining chunks, call `deletePreference(key, { storage: 'split' })`.
+- **Orphan chunks** (chunk keys with no root or a different root, e.g. from a failed write): Not auto-deleted by reads. A later successful `updatePreference(key, value, { storage: 'split' })` (or `'auto'` with long value) deletes old chunks from the previous root **and** any chunk keys for that prefix that are not in the new root, so orphan chunks are cleaned up on the next successful split write.

--- a/examples/getPreferences.md
+++ b/examples/getPreferences.md
@@ -1,15 +1,49 @@
 # getPreferences
 
+Fetches all preferences for the logged-in user. Default is `handleStorage: 'merged'`: one entry per logical key (split keys merged). Use `handleStorage: 'raw'` for API keys as returned. Returns `Record<string, string>` (merged or raw).
+
+## Split keys
+
+See [Split storage](updatePreference.md#split-storage) for how values >255 chars are stored.
+
+## Example
+
+### Database state
+
+Assume the OSM DB has the following data in the user's preferences:
+
+```yaml
+# Single key
+my-key=foobar
+
+# Split key
+my-key:root=a1b2c3d4,e5f6g7h8
+my-key:a1b2c3d4={"theme":"dark","fontSize":14,"items":["a","b","c",
+my-key:e5f6g7h8="d","e"]}
+```
+
+### Get with `handleStorage: merged`
+
+`merged` is the default. One entry per logical key; split keys merged into a single value. This helper does not support types or a parser at the moment—values are raw strings. For typed, validated reads use [getPreference](getPreference.md) with a schema; see [Schema and types](updatePreference.md#schema-and-types) in updatePreference.md.
+
 ```ts
 import { getPreferences } from "osm-api";
 
-await getPreferences();
+const merged = await getPreferences();
+// or…
+const merged = await getPreferences({ handleStorage: "merged" });
+// → Record<string, string>
+console.log(merged);
+// With example DB: { "my-key": "{\"theme\":\"dark\",\"fontSize\":14,\"items\":[\"a\",\"b\",\"c\",\"d\",\"e\"]}" }
 ```
 
-Response:
+### Get with `handleStorage: raw`
 
-```json
-{
-  "some key": "some value"
-}
+API keys as returned. Split keys appear as separate entries.
+
+```ts
+const raw = await getPreferences({ handleStorage: "raw" });
+// → Record<string, string>
+console.log(raw);
+// With example DB: { "my-key": "foobar", "my-key:root": "a1b2c3d4,e5f6g7h8", "my-key:a1b2c3d4": "{\"theme\":\"dark\",\"fontSize\":14,\"items\":[\"a\",\"b\",\"c\",", "my-key:e5f6g7h8": "\"d\",\"e\"]}" }
 ```

--- a/examples/getPreferences.md
+++ b/examples/getPreferences.md
@@ -24,7 +24,9 @@ my-key:e5f6g7h8="d","e"]}
 
 ### Get with `handleStorage: merged`
 
-`merged` is the default. One entry per logical key; split keys merged into a single value. This helper does not support types or a parser at the moment—values are raw strings. For typed, validated reads use [getPreference](getPreference.md) with a schema; see [Schema and types](updatePreference.md#schema-and-types) in updatePreference.md.
+`merged` is the default. One entry per logical key; split keys merged into a single value. If both single and split forms exist for the same logical key, the merged output uses the split value when the split data is complete/valid. If split data is incomplete (for example, root present but a chunk missing), the split value is ignored for merged output.
+
+This helper does not support types or a parser at the moment—values are raw strings. For typed, validated reads use [getPreference](getPreference.md) with a schema; see [Schema and types](updatePreference.md#schema-and-types) in updatePreference.md.
 
 ```ts
 import { getPreferences } from "osm-api";

--- a/examples/updatePreference.md
+++ b/examples/updatePreference.md
@@ -1,0 +1,149 @@
+# updatePreference
+
+Writes one preference by key. Value is JSON-serialized. With `storage: 'auto'` (default), values ≤255 chars use a single API key; longer values use split storage. For schema (e.g. Zod) and types for get/update, see [Schema and types](#schema-and-types) below.
+
+## Key format
+
+The **logical key** (e.g. `mykey`, `foo:bar`, `ESS:editor-settings`) can contain colons. For split storage we append `:root` and `:hash` (8 hex chars) to form API keys; we do not treat `:` as reserved in your key. The key **must not** contain `/`, `?`, `#`, or `\` (unsafe in the OSM API path). If it does, the function **throws** with a message like `Preference key must not contain / ? # or \\ (unsafe in URL path): "your-key"`. Emojis and other non-ASCII are not validated; they may work depending on server encoding.
+
+## Split storage
+
+The OSM API allows one string per key, max 255 characters. For longer values, the library stores one logical preference as **split storage**: multiple API keys (a root manifest plus content-hashed chunks).
+
+- **Single key:** one entry, e.g. `mykey` → `"short"`.
+- **Split storage:** one logical key becomes several entries. Example after `updatePreference("ESS:editor-settings", longJsonString)` with `storage: 'auto'` (length > 255):
+
+| Key (raw)                      | Value                                                         |
+| ------------------------------ | ------------------------------------------------------------- |
+| `ESS:editor-settings:root`     | `a1b2c3d4,e5f6g7h8` (comma-separated 8-char hashes, in order) |
+| `ESS:editor-settings:a1b2c3d4` | first 255 chars of the serialized value                       |
+| `ESS:editor-settings:e5f6g7h8` | remainder                                                     |
+
+**How split write works (chunks first, then root, retries):**
+
+To handle network errors better, the library writes split storage in this order:
+
+1. **Chunks in parallel:** All chunk keys (`key:hash`) are written with `Promise.all`. Each chunk PUT is retried up to **3 times** (initial attempt + 2 retries) on failure. If a chunk still fails after retries, the function throws; some chunk keys may be written (orphans) but the root is not, so readers still see the previous state (or nothing).
+2. **Root:** One PUT for `key:root` with a comma-separated list of chunk hashes. If this fails, the function throws; chunks are already written (orphans until the next successful update overwrites/cleans).
+3. **Delete old chunks:** Chunk keys that are no longer in the new root are deleted (including orphan chunks from earlier failed writes).
+
+**Max size for one split preference:**
+
+In this format you can store about **7.1 KB** of text (7140 characters) per logical key. `PREFERENCE_SPLIT_MAX_PAYLOAD_BYTES` (exported from the package) is that maximum length in **characters**. It comes from the OSM limit of 255 chars per key value: the root value holds a comma-separated list of chunk hashes (8 chars each + comma), so at most 28 hashes fit; each chunk is ≤255 chars, so 28×255 = 7140. If your serialized value is longer, `updatePreference(..., { storage: "split" })` or `storage: "auto"` with a long value will throw. Check before writing:
+
+```ts
+import { PREFERENCE_SPLIT_MAX_PAYLOAD_BYTES, updatePreference } from "osm-api";
+
+const serialized = JSON.stringify(largeObject);
+if (serialized.length > PREFERENCE_SPLIT_MAX_PAYLOAD_BYTES) {
+  // Store under multiple logical keys (e.g. mykey:0, mykey:1) or shorten the value
+} else {
+  await updatePreference("mykey", largeObject, { storage: "split" });
+}
+```
+
+## Schema and types
+
+> [!NOTE]
+> Prefer using `updatePreference` with a runtime validation schema (e.g. [Zod](https://zod.dev)) so you get typed, validated data and clear parse/validation errors.
+
+- **getPreference without schema:** Returns `string | null`. Your app must parse and validate (e.g. `JSON.parse` + manual checks).
+- **getPreference with schema:** Returns `PreferenceResult<T>`: `{ value: T }` on success, `{ issues }` on parse/validation failure, or `null` if the key is missing. Validation failures are returned as `{ issues }` (no throw) so the caller can inspect and decide.
+- **updatePreference with schema:** Value is validated before writing; **throws** if validation fails. Throwing avoids persisting invalid data; use `try/catch` to handle.
+
+The schema can be any [Standard Schema](https://github.com/standard-schema/standard-schema)–compatible implementation (e.g. Zod, Valibot).
+
+## Examples
+
+### Database state
+
+Lets assume the OSM DB has the following data in the user's preferences:
+
+```yaml
+# Single key
+my-key=foobar
+
+# Split key
+my-key:root=a1b2c3d4,e5f6g7h8
+my-key:a1b2c3d4={"theme":"dark","fontSize":14,"items":["a","b","c",
+my-key:e5f6g7h8="d","e"]}
+```
+
+### Update with `storage: auto`
+
+`auto` is the default. Single API key if serialized length ≤255; otherwise split (root + chunks). If **both** single and split exist for the same key it **throws** (use `storage: 'single'` or `'split'` to resolve, or delete the other form first with `deletePreference(key, { storage: 'single' })` or `deletePreference(key, { storage: 'split' })` then update).
+
+With the example DB state above, `my-key` exists as both single and split, so the following **throws**. Use `storage: 'single'` or `'split'` (below) to update.
+
+```ts
+import { updatePreference } from "osm-api";
+
+// With example DB state (both present) this throws:
+await updatePreference("my-key", { theme: "dark" });
+// or…
+await updatePreference("my-key", { theme: "dark" }, { storage: "auto" });
+// → throws  Use storage: 'single' or 'split' to update.
+```
+
+Example when only one storage form is present (e.g. after deleting the single key so only split remains):
+
+```ts
+import { deletePreference, updatePreference } from "osm-api";
+
+// With example DB state (both present): remove single key so only split remains
+await deletePreference("my-key", { storage: "single" });
+// Now only the split keys (root + chunks) are present; update with auto works
+await updatePreference("my-key", { theme: "dark" });
+// → void  After: my-key={"theme":"dark"}  (single key written)
+```
+
+### Update with `storage: single`
+
+One API key only. Throws if serialized length > 255.
+
+```ts
+await updatePreference("my-key", "foobar", { storage: "single" });
+// → void  After: my-key="foobar"  (stored as JSON string, i.e. "foobar" with quotes in value)
+```
+
+### Update with `storage: split`
+
+Always store as split (root + chunks), even if ≤255 chars.
+
+```ts
+await updatePreference("my-key", { data: "..." }, { storage: "split" });
+// → void  After: my-key:root=..., my-key:hash1=..., ...
+```
+
+### With schema (validates before writing)
+
+Pass a [Standard Schema](https://github.com/standard-schema/standard-schema)–compatible schema (e.g. [Zod](https://zod.dev)); the value is validated before writing. See [Schema and types](#schema-and-types) above.
+
+Unlike `getPreference` with schema (which returns `{ issues }`), validation failure here **throws**. The thrown error message includes the schema issues (e.g. `Preference validation failed: [{"message":"..."}]`). Use `try/catch` to handle and log.
+
+```ts
+import { updatePreference } from "osm-api";
+import { z } from "zod";
+
+const mySchema = z.object({ theme: z.string(), fontSize: z.number() });
+try {
+  await updatePreference("settings", userInput, { schema: mySchema });
+  // → void
+} catch (err) {
+  if (
+    err instanceof Error &&
+    /Preference validation failed/.test(err.message)
+  ) {
+    console.error("Validation failed:", err.message);
+  }
+  throw err;
+}
+```
+
+## Error cases
+
+- **Invalid key:** If the key contains `/`, `?`, `#`, or `\` → **throws** with a message (see [Key format](#key-format)).
+- **Conflict (auto only):** The key exists as **both** a single key and split storage → **throws** with a message; use `storage: 'single'` or `'split'` to update.
+- **Schema validation failure:** If `schema` is provided and validation fails, **throws** before writing.
+- **Storage `single` and length > 255:** If serialized value exceeds 255 chars, **throws**.
+- **Network / auth:** If a chunk write still fails after retries (3 attempts per chunk), the function throws; some chunk keys may be written (orphans) but the root is not. If the root write fails, the function throws; chunks are already written (orphans until the next successful update).

--- a/examples/updatePreference.md
+++ b/examples/updatePreference.md
@@ -97,6 +97,8 @@ await updatePreference("my-key", { theme: "dark" });
 // → void  After: my-key={"theme":"dark"}  (single key written)
 ```
 
+When updating with explicit `storage: 'single'` or `storage: 'split'`, the library also removes the other storage form if it exists for that key, so future `storage: 'auto'` reads/writes do not hit single/split conflict errors.
+
 ### Update with `storage: single`
 
 One API key only. Throws if serialized length > 255.

--- a/examples/updatePreferences.md
+++ b/examples/updatePreferences.md
@@ -1,11 +1,43 @@
 # updatePreferences
 
+**Deprecated.** Writes a single API key only (raw string, ≤255 chars); equivalent in scope to `updatePreference(key, value, { storage: 'single' })` (one key, no split). Note: `updatePreference` JSON-serializes values, so stored bytes differ. Prefer `updatePreference` for JSON, schema, or split storage. Returns `void`.
+
+## Split keys
+
+See [Split storage](updatePreference.md#split-storage).
+
+## Example
+
+### Database state
+
+Lets assume the OSM DB has the following data in the user's preferences:
+
+```yaml
+# Single key
+my-key=foobar
+
+# Split key
+my-key:root=a1b2c3d4,e5f6g7h8
+my-key:a1b2c3d4={"theme":"dark","fontSize":14,"items":["a","b","c",
+my-key:e5f6g7h8="d","e"]}
+```
+
+### Add (single key only)
+
+Adding a key not in the example above. After the call, the key is set.
+
 ```ts
 import { updatePreferences } from "osm-api";
 
-await updatePreferences("key", "value");
+await updatePreferences("other-key", "value");
+// → void
 ```
 
-Response:
+### Update (single key only)
 
-_none_
+With the example DB, `my-key=foobar`. After the call, `my-key` is overwritten.
+
+```ts
+await updatePreferences("my-key", "value");
+// → void
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.3.2",
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/geojson": "^7946.0.13",
         "fast-xml-parser": "^4.4.1"
       },
@@ -658,7 +659,6 @@
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.2",
         "debug": "^4.3.1",
@@ -687,8 +687,7 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.3.0",
@@ -1039,17 +1038,11 @@
         "win32"
       ]
     },
-    "node_modules/@types/eslint": {
-      "version": "8.56.2",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.2.tgz",
-      "integrity": "sha512-uQDwm1wFHmbBbCZCqAlq6Do9LYwByNZHWzXppSnay9SuwJ+VRbjkbLABer54kcPnMSlG6Fdiy2yaFXm/z9Z5gw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
@@ -1063,20 +1056,13 @@
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.13.tgz",
       "integrity": "sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ=="
     },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/node": {
       "version": "22.5.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
       "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1128,6 +1114,7 @@
       "integrity": "sha512-gF77eNv0Xz2UJg/NbpWJ0kqAm35UMsvZf1GHj8D9MRFTj/V3tAciIWXfmPLsAAF/vUlpWPvUDyH1jjsr0cMVWw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.5.0",
         "@typescript-eslint/types": "8.5.0",
@@ -1309,8 +1296,7 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
@@ -1431,6 +1417,7 @@
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1879,6 +1866,7 @@
       "integrity": "sha512-SaHqzhku9v/j6XsQMRxPyBrSP3gnwmE27gLJYZgMT2GeK3J0+0toN+MnuNYDfHwVGQfLiMZ7KSNSIXHemy905w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assert": "^1.4.0",
         "browser-pack": "^6.0.1",
@@ -2046,6 +2034,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001646",
         "electron-to-chromium": "^1.5.4",
@@ -3035,6 +3024,7 @@
       "integrity": "sha512-Y4D0IgtBZfOcOUAIQTSXBKoNGfY0REGqHJG6+Q81vNippW5YlKjHFj4soMxamKK1NXHUWuBZTLdU3Km+L/pcHw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.11.0",
@@ -3121,7 +3111,6 @@
       "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -3146,7 +3135,6 @@
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -3163,7 +3151,6 @@
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3233,7 +3220,6 @@
       "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -3251,7 +3237,6 @@
       "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -3262,7 +3247,6 @@
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -3279,7 +3263,6 @@
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -3298,7 +3281,6 @@
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -3312,7 +3294,6 @@
       "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.3",
@@ -3341,6 +3322,7 @@
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5859,6 +5841,7 @@
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6281,7 +6264,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -7172,7 +7154,6 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7269,6 +7250,7 @@
       "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7457,6 +7439,7 @@
       "integrity": "sha512-6ANcZRivqL/4WtwPGTKNaosuNJr5tWiftOC7liM7G9+rMb8+oeJeyzymDu4rTN93seySBmbjSfsS3Vzr19KNtA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -7540,6 +7523,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "@standard-schema/spec": "^1.1.0",
     "@types/geojson": "^7946.0.13",
     "fast-xml-parser": "^4.4.1"
   },

--- a/src/api/preferences/__tests__/chunked.test.ts
+++ b/src/api/preferences/__tests__/chunked.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "vitest";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import {
+  type PackChunkedResult,
+  assertPreferenceKey,
+  hasSingleKey,
+  hasSplitKey,
+  mergePreferencesToLogical,
+  packChunked,
+  resolveValueForKey,
+  unpackChunked,
+} from "../chunked";
+
+/** Mock Standard Schema that accepts object with foo string and returns it. */
+const passThroughSchema: StandardSchemaV1<unknown, { foo: string }> = {
+  "~standard": {
+    version: 1,
+    vendor: "test",
+    types: { input: undefined as unknown, output: { foo: "" } },
+    validate(value: unknown) {
+      if (
+        value &&
+        typeof value === "object" &&
+        "foo" in value &&
+        typeof (value as { foo: unknown }).foo === "string"
+      ) {
+        return { value: value as { foo: string } };
+      }
+      return { issues: [{ message: "expected object with foo string" }] };
+    },
+  },
+};
+
+async function roundTrip(
+  prefix: string,
+  value: string,
+  previousRootValue?: string
+): Promise<{ packed: PackChunkedResult; unpacked: string | null }> {
+  const packed = await packChunked(prefix, value, previousRootValue, 255);
+  const preferences: Record<string, string> = {
+    [packed.rootKey]: packed.rootValue,
+    ...packed.chunks,
+  };
+  const unpacked = unpackChunked(preferences, prefix);
+  return { packed, unpacked };
+}
+
+describe("assertPreferenceKey", () => {
+  it("throws when key contains /", () => {
+    expect(() => assertPreferenceKey("key/path")).toThrow(
+      /Preference key must not contain.*unsafe in URL path/
+    );
+  });
+  it("throws when key contains ?", () => {
+    expect(() => assertPreferenceKey("key?query")).toThrow(
+      /Preference key must not contain.*unsafe in URL path/
+    );
+  });
+  it("throws when key contains #", () => {
+    expect(() => assertPreferenceKey("key#hash")).toThrow(
+      /Preference key must not contain.*unsafe in URL path/
+    );
+  });
+  it("throws when key contains \\", () => {
+    expect(() => assertPreferenceKey("key\\back")).toThrow(
+      /Preference key must not contain.*unsafe in URL path/
+    );
+  });
+  it("does not throw for key with colon", () => {
+    expect(() => assertPreferenceKey("foo:bar")).not.toThrow();
+  });
+  it("does not throw for simple key", () => {
+    expect(() => assertPreferenceKey("mykey")).not.toThrow();
+  });
+});
+
+describe("packChunked", () => {
+  it("exposes MAX_PAYLOAD_BYTES to consumers", () => {
+    expect(packChunked.MAX_PAYLOAD_BYTES).toBeTypeOf("number");
+    expect(packChunked.MAX_PAYLOAD_BYTES).toBe(28 * 255);
+  });
+
+  it("round-trips empty string", async () => {
+    const { packed, unpacked } = await roundTrip("ESS", "");
+    expect(unpacked).toBe("");
+    expect(packed.rootKey).toBe("ESS:root");
+    expect(packed.oldKeysToDelete).toStrictEqual([]);
+    expect(Object.keys(packed.chunks)).toHaveLength(1);
+  });
+
+  it("round-trips single-chunk string under 255 chars", async () => {
+    const value = "hello";
+    const { packed, unpacked } = await roundTrip("ESS", value);
+    expect(unpacked).toBe(value);
+    expect(packed.rootKey).toBe("ESS:root");
+    expect(packed.oldKeysToDelete).toStrictEqual([]);
+    expect(Object.keys(packed.chunks)).toHaveLength(1);
+  });
+
+  it("round-trips multi-chunk string", async () => {
+    const value = `${"a".repeat(255)}${"b".repeat(255)}tail`;
+    const { packed, unpacked } = await roundTrip("ESS", value);
+    expect(unpacked).toBe(value);
+    expect(packed.rootKey).toBe("ESS:root");
+    const hashes = packed.rootValue.split(",");
+    expect(hashes).toHaveLength(3);
+    expect(Object.keys(packed.chunks)).toHaveLength(3);
+  });
+
+  it("returns same hash for same chunk content", async () => {
+    const value = "same";
+    const a = await packChunked("P", value);
+    const b = await packChunked("P", value);
+    expect(a.rootValue).toBe(b.rootValue);
+    expect(Object.keys(a.chunks)[0]).toBe(Object.keys(b.chunks)[0]);
+  });
+
+  it("computes oldKeysToDelete from previous root", async () => {
+    const first = await packChunked("P", "old");
+    const second = await packChunked("P", "new", first.rootValue, 255);
+    expect(second.oldKeysToDelete).toHaveLength(1);
+    expect(second.oldKeysToDelete[0]).toMatch(/^P:[\da-f]{8}$/);
+  });
+
+  it("throws when value exceeds MAX_PAYLOAD_BYTES", async () => {
+    const tooLong = "x".repeat(packChunked.MAX_PAYLOAD_BYTES + 1);
+    await expect(packChunked("ESS", tooLong)).rejects.toThrow(
+      /Preference value exceeds maximum size/
+    );
+  });
+});
+
+describe("unpackChunked", () => {
+  it("returns null when root is missing", () => {
+    expect(unpackChunked({}, "ESS")).toBeNull();
+  });
+
+  it("returns null when root is empty string", () => {
+    expect(unpackChunked({ "ESS:root": "" }, "ESS")).toBeNull();
+  });
+
+  it("returns null when a chunk is missing", async () => {
+    const value = "a".repeat(300);
+    const packed = await packChunked("ESS", value);
+    const chunkKeys = Object.keys(packed.chunks);
+    const preferences: Record<string, string> = {
+      [packed.rootKey]: packed.rootValue,
+      [chunkKeys[0]!]: packed.chunks[chunkKeys[0]!]!,
+      // omit chunkKeys[1]
+    };
+    expect(unpackChunked(preferences, "ESS")).toBeNull();
+  });
+
+  it("returns concatenated string when all chunks present", async () => {
+    const value = "a".repeat(300);
+    const { packed, unpacked } = await roundTrip("X", value);
+    expect(unpacked).toBe(value);
+    expect(packed.chunks).toBeDefined();
+  });
+
+  it("with schema returns { value } for valid JSON that passes validation", async () => {
+    const json = JSON.stringify({ foo: "bar" });
+    const packed = await packChunked("ESS", json);
+    const preferences: Record<string, string> = {
+      [packed.rootKey]: packed.rootValue,
+      ...packed.chunks,
+    };
+    const result = await unpackChunked(preferences, "ESS", passThroughSchema);
+    expect(result).not.toBeNull();
+    expect("value" in result!).toBe(true);
+    expect((result as { value: { foo: string } }).value).toStrictEqual({
+      foo: "bar",
+    });
+  });
+
+  it("with schema returns { issues } for invalid JSON", async () => {
+    const packed = await packChunked("ESS", "not json {");
+    const preferences: Record<string, string> = {
+      [packed.rootKey]: packed.rootValue,
+      ...packed.chunks,
+    };
+    const result = await unpackChunked(preferences, "ESS", passThroughSchema);
+    expect(result).not.toBeNull();
+    expect("issues" in result!).toBe(true);
+    expect(
+      (result as { issues: readonly { message: string }[] }).issues[0]?.message
+    ).toBe("Invalid JSON");
+  });
+
+  it("with schema returns { issues } when validation fails", async () => {
+    const packed = await packChunked("ESS", JSON.stringify({ bar: 1 }));
+    const preferences: Record<string, string> = {
+      [packed.rootKey]: packed.rootValue,
+      ...packed.chunks,
+    };
+    const result = await unpackChunked(preferences, "ESS", passThroughSchema);
+    expect(result).not.toBeNull();
+    expect("issues" in result!).toBe(true);
+  });
+
+  it("with schema returns null when raw is null", async () => {
+    const result = await unpackChunked({}, "ESS", passThroughSchema);
+    expect(result).toBeNull();
+  });
+});
+
+describe("hasSingleKey / hasSplitKey / resolveValueForKey", () => {
+  it("hasSingleKey true when key present", () => {
+    expect(hasSingleKey({ foo: "v" }, "foo")).toBe(true);
+    expect(hasSingleKey({ foo: "" }, "foo")).toBe(true);
+  });
+  it("hasSingleKey false when key absent", () => {
+    expect(hasSingleKey({}, "foo")).toBe(false);
+    expect(hasSingleKey({ "foo:root": "x" }, "foo")).toBe(false);
+  });
+  it("hasSplitKey true when prefix:root present", () => {
+    expect(hasSplitKey({ "foo:root": "h1" }, "foo")).toBe(true);
+  });
+  it("hasSplitKey false when no root", () => {
+    expect(hasSplitKey({}, "foo")).toBe(false);
+    expect(hasSplitKey({ foo: "v" }, "foo")).toBe(false);
+  });
+  it("resolveValueForKey single mode returns value or null", () => {
+    expect(resolveValueForKey({ foo: "v" }, "foo", "single")).toBe("v");
+    expect(resolveValueForKey({}, "foo", "single")).toBeNull();
+  });
+  it("resolveValueForKey split mode uses unpackChunkedRaw", async () => {
+    const packed = await packChunked("P", "hello");
+    const prefs: Record<string, string> = {
+      [packed.rootKey]: packed.rootValue,
+      ...packed.chunks,
+    };
+    expect(resolveValueForKey(prefs, "P", "split")).toBe("hello");
+    expect(resolveValueForKey(prefs, "P", "split")).toBe("hello");
+    expect(resolveValueForKey({}, "P", "split")).toBeNull();
+  });
+  it("resolveValueForKey auto returns single when only single", () => {
+    expect(resolveValueForKey({ foo: "v" }, "foo", "auto")).toBe("v");
+  });
+  it("resolveValueForKey auto returns split when only split", async () => {
+    const packed = await packChunked("P", "x");
+    const prefs: Record<string, string> = {
+      [packed.rootKey]: packed.rootValue,
+      ...packed.chunks,
+    };
+    expect(resolveValueForKey(prefs, "P", "auto")).toBe("x");
+  });
+  it("resolveValueForKey auto throws when both single and split", async () => {
+    const packed = await packChunked("P", "x");
+    const prefs: Record<string, string> = {
+      P: "single",
+      [packed.rootKey]: packed.rootValue,
+      ...packed.chunks,
+    };
+    expect(() => resolveValueForKey(prefs, "P", "auto")).toThrow(
+      /exists as both a single key and split storage/
+    );
+  });
+});
+
+describe("mergePreferencesToLogical", () => {
+  it("passes through single keys", () => {
+    const prefs = { a: "1", b: "2" };
+    expect(mergePreferencesToLogical(prefs)).toStrictEqual({ a: "1", b: "2" });
+  });
+  it("merges split prefix into one entry", async () => {
+    const packed = await packChunked("ESS", "chunked-value");
+    const prefs: Record<string, string> = {
+      [packed.rootKey]: packed.rootValue,
+      ...packed.chunks,
+    };
+    const merged = mergePreferencesToLogical(prefs);
+    expect(merged).toStrictEqual({ ESS: "chunked-value" });
+  });
+  it("combines single keys and merged split", async () => {
+    const packed = await packChunked("P", "p-value");
+    const prefs: Record<string, string> = {
+      single: "v",
+      [packed.rootKey]: packed.rootValue,
+      ...packed.chunks,
+    };
+    const merged = mergePreferencesToLogical(prefs);
+    expect(merged["single"]).toBe("v");
+    expect(merged["P"]).toBe("p-value");
+    expect(Object.keys(merged)).toHaveLength(2);
+  });
+  it("merges split when logical key contains colon (e.g. foo:bar)", async () => {
+    const packed = await packChunked("foo:bar", "x");
+    const prefs: Record<string, string> = {
+      [packed.rootKey]: packed.rootValue,
+      ...packed.chunks,
+    };
+    const merged = mergePreferencesToLogical(prefs);
+    expect(merged["foo:bar"]).toBe("x");
+    expect(Object.keys(merged)).toHaveLength(1);
+  });
+});

--- a/src/api/preferences/__tests__/chunked.test.ts
+++ b/src/api/preferences/__tests__/chunked.test.ts
@@ -62,7 +62,7 @@ describe("assertPreferenceKey", () => {
     );
   });
   it("throws when key contains \\", () => {
-    expect(() => assertPreferenceKey("key\\back")).toThrow(
+    expect(() => assertPreferenceKey(String.raw`key\back`)).toThrow(
       /Preference key must not contain.*unsafe in URL path/
     );
   });
@@ -283,6 +283,16 @@ describe("mergePreferencesToLogical", () => {
     expect(merged["single"]).toBe("v");
     expect(merged["P"]).toBe("p-value");
     expect(Object.keys(merged)).toHaveLength(2);
+  });
+  it("prefers valid split value when both single and split exist", async () => {
+    const packed = await packChunked("P", "split-value");
+    const prefs: Record<string, string> = {
+      [packed.rootKey]: packed.rootValue,
+      ...packed.chunks,
+      P: "single-value",
+    };
+    const merged = mergePreferencesToLogical(prefs);
+    expect(merged["P"]).toBe("split-value");
   });
   it("merges split when logical key contains colon (e.g. foo:bar)", async () => {
     const packed = await packChunked("foo:bar", "x");

--- a/src/api/preferences/__tests__/deletePreference.test.ts
+++ b/src/api/preferences/__tests__/deletePreference.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { deletePreferences } from "../deletePreferences";
+import { deletePreference } from "../deletePreference";
+import { getPreferences } from "../getPreferences";
+
+vi.mock("../getPreferences", () => ({
+  getPreferences: vi.fn(),
+}));
+vi.mock("../deletePreferences", () => ({
+  deletePreferences: vi.fn(),
+}));
+
+describe("deletePreference", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws for invalid key", async () => {
+    await expect(deletePreference("bad/key")).rejects.toThrow(
+      /Preference key must not contain.*unsafe in URL path/
+    );
+  });
+
+  it("auto deletes single and split storage when both exist", async () => {
+    vi.mocked(getPreferences).mockResolvedValue({
+      P: "single",
+      "P:root": "aaaaaaaa",
+      "P:aaaaaaaa": "split",
+    });
+    vi.mocked(deletePreferences).mockResolvedValue();
+
+    await deletePreference("P", { storage: "auto" });
+
+    expect(deletePreferences).toHaveBeenCalledWith("P", { storage: "auto" });
+    expect(deletePreferences).toHaveBeenCalledWith("P:root", {
+      storage: "auto",
+    });
+    expect(deletePreferences).toHaveBeenCalledWith("P:aaaaaaaa", {
+      storage: "auto",
+    });
+  });
+
+  it("single mode only deletes the single key", async () => {
+    vi.mocked(getPreferences).mockResolvedValue({
+      P: "single",
+      "P:root": "aaaaaaaa",
+      "P:aaaaaaaa": "split",
+    });
+    vi.mocked(deletePreferences).mockResolvedValue();
+
+    await deletePreference("P", { storage: "single" });
+
+    expect(deletePreferences).toHaveBeenCalledTimes(1);
+    expect(deletePreferences).toHaveBeenCalledWith("P", { storage: "single" });
+  });
+
+  it("split mode only deletes split keys", async () => {
+    vi.mocked(getPreferences).mockResolvedValue({
+      P: "single",
+      "P:root": "aaaaaaaa",
+      "P:aaaaaaaa": "split",
+    });
+    vi.mocked(deletePreferences).mockResolvedValue();
+
+    await deletePreference("P", { storage: "split" });
+
+    expect(deletePreferences).not.toHaveBeenCalledWith("P", {
+      storage: "split",
+    });
+    expect(deletePreferences).toHaveBeenCalledWith("P:root", {
+      storage: "split",
+    });
+    expect(deletePreferences).toHaveBeenCalledWith("P:aaaaaaaa", {
+      storage: "split",
+    });
+  });
+});

--- a/src/api/preferences/__tests__/getPreference.test.ts
+++ b/src/api/preferences/__tests__/getPreference.test.ts
@@ -1,0 +1,101 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getPreference } from "../getPreference";
+import { getPreferences } from "../getPreferences";
+
+vi.mock("../getPreferences", () => ({
+  getPreferences: vi.fn(),
+}));
+
+const objectSchema: StandardSchemaV1<unknown, { foo: string }> = {
+  "~standard": {
+    version: 1,
+    vendor: "test",
+    types: { input: undefined as unknown, output: { foo: "" } },
+    validate(value: unknown) {
+      if (
+        value &&
+        typeof value === "object" &&
+        "foo" in value &&
+        typeof (value as { foo: unknown }).foo === "string"
+      ) {
+        return { value: value as { foo: string } };
+      }
+      return { issues: [{ message: "expected object with foo string" }] };
+    },
+  },
+};
+
+describe("getPreference", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws for invalid key", async () => {
+    await expect(getPreference("bad/key")).rejects.toThrow(
+      /Preference key must not contain.*unsafe in URL path/
+    );
+  });
+
+  it("returns single value with storage: single", async () => {
+    vi.mocked(getPreferences).mockResolvedValue({ P: "single" });
+
+    await expect(getPreference("P", { storage: "single" })).resolves.toBe(
+      "single"
+    );
+  });
+
+  it("returns split value with storage: split", async () => {
+    vi.mocked(getPreferences).mockResolvedValue({
+      "P:root": "aaaaaaaa",
+      "P:aaaaaaaa": "split",
+    });
+
+    await expect(getPreference("P", { storage: "split" })).resolves.toBe(
+      "split"
+    );
+  });
+
+  it("returns null when split chunk is missing", async () => {
+    vi.mocked(getPreferences).mockResolvedValue({
+      "P:root": "aaaaaaaa,bbbbbbbb",
+      "P:aaaaaaaa": "hello",
+      // P:bbbbbbbb missing
+    });
+
+    await expect(getPreference("P", { storage: "split" })).resolves.toBeNull();
+  });
+
+  it("throws with storage auto when both single and split exist", async () => {
+    vi.mocked(getPreferences).mockResolvedValue({
+      P: "single",
+      "P:root": "aaaaaaaa",
+      "P:aaaaaaaa": "split",
+    });
+
+    await expect(getPreference("P", { storage: "auto" })).rejects.toThrow(
+      /exists as both a single key and split storage/
+    );
+  });
+
+  it("returns { value } for valid schema data", async () => {
+    vi.mocked(getPreferences).mockResolvedValue({
+      "P:root": "aaaaaaaa",
+      "P:aaaaaaaa": JSON.stringify({ foo: "bar" }),
+    });
+
+    await expect(
+      getPreference("P", { storage: "split", schema: objectSchema })
+    ).resolves.toStrictEqual({ value: { foo: "bar" } });
+  });
+
+  it("returns { issues } for invalid JSON with schema", async () => {
+    vi.mocked(getPreferences).mockResolvedValue({
+      P: "not-json",
+    });
+
+    await expect(
+      getPreference("P", { storage: "single", schema: objectSchema })
+    ).resolves.toStrictEqual({ issues: [{ message: "Invalid JSON" }] });
+  });
+});

--- a/src/api/preferences/__tests__/getPreferences.test.ts
+++ b/src/api/preferences/__tests__/getPreferences.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getPreferences } from "../getPreferences";
+import { osmFetch } from "../../_osmFetch";
+
+vi.mock("../../_osmFetch", () => ({
+  osmFetch: vi.fn(),
+}));
+
+describe("getPreferences", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns raw API keys with handleStorage: raw", async () => {
+    vi.mocked(osmFetch).mockResolvedValue({
+      preferences: {
+        P: "single",
+        "P:root": "aaaaaaaa",
+        "P:aaaaaaaa": "split",
+      },
+    });
+
+    await expect(
+      getPreferences({ handleStorage: "raw" })
+    ).resolves.toStrictEqual({
+      P: "single",
+      "P:root": "aaaaaaaa",
+      "P:aaaaaaaa": "split",
+    });
+  });
+
+  it("returns merged logical keys by default", async () => {
+    vi.mocked(osmFetch).mockResolvedValue({
+      preferences: {
+        P: "single",
+        "P:root": "aaaaaaaa",
+        "P:aaaaaaaa": "split",
+        X: "value",
+      },
+    });
+
+    await expect(getPreferences()).resolves.toStrictEqual({
+      P: "split",
+      X: "value",
+    });
+  });
+});

--- a/src/api/preferences/__tests__/legacyPreferences.test.ts
+++ b/src/api/preferences/__tests__/legacyPreferences.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { osmFetch } from "../../_osmFetch";
+import { deletePreferences } from "../deletePreferences";
+import { updatePreferences } from "../updatePreferences";
+
+vi.mock("../../_osmFetch", () => ({
+  osmFetch: vi.fn(),
+}));
+
+describe("legacy preference APIs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updatePreferences writes one raw key", async () => {
+    vi.mocked(osmFetch).mockResolvedValue("");
+
+    await updatePreferences("my-key", "value", {
+      headers: { "X-Test-Header": "token" },
+    });
+
+    expect(osmFetch).toHaveBeenCalledWith(
+      "/0.6/user/preferences/my-key.json",
+      {},
+      {
+        headers: { "X-Test-Header": "token" },
+        method: "PUT",
+        body: "value",
+      }
+    );
+  });
+
+  it("deletePreferences deletes one raw key", async () => {
+    vi.mocked(osmFetch).mockResolvedValue("");
+
+    await deletePreferences("my-key", {
+      headers: { "X-Test-Header": "token" },
+    });
+
+    expect(osmFetch).toHaveBeenCalledWith(
+      "/0.6/user/preferences/my-key.json",
+      {},
+      {
+        headers: { "X-Test-Header": "token" },
+        method: "DELETE",
+      }
+    );
+  });
+});

--- a/src/api/preferences/__tests__/setChunkedPreference.test.ts
+++ b/src/api/preferences/__tests__/setChunkedPreference.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { setChunkedPreference } from "../chunked";
+import { deletePreferences } from "../deletePreferences";
+import { getPreferences } from "../getPreferences";
+import { updatePreferences } from "../updatePreferences";
+
+vi.mock("../getPreferences", () => ({ getPreferences: vi.fn() }));
+vi.mock("../updatePreferences", () => ({ updatePreferences: vi.fn() }));
+vi.mock("../deletePreferences", () => ({ deletePreferences: vi.fn() }));
+
+describe("setChunkedPreference", () => {
+  it("writes chunks in parallel first, then root, then deletes old keys", async () => {
+    const updateCalls: [string, string][] = [];
+    vi.mocked(getPreferences).mockResolvedValue({});
+    vi.mocked(updatePreferences).mockImplementation(async (key, value) => {
+      updateCalls.push([key, value]);
+    });
+    vi.mocked(deletePreferences).mockResolvedValue();
+
+    await setChunkedPreference("P", "x");
+
+    expect(updateCalls.length).toBeGreaterThanOrEqual(2);
+    const rootCall = updateCalls.find(([k]) => k === "P:root");
+    expect(rootCall).toBeDefined();
+    expect(updateCalls[updateCalls.length - 1]![0]).toBe("P:root");
+    const chunkCalls = updateCalls.slice(0, -1);
+    expect(
+      chunkCalls.every(([k]) => k.startsWith("P:") && k !== "P:root")
+    ).toBe(true);
+    // No previous root, so oldKeysToDelete is empty and deletePreferences may not be called
+  });
+
+  it("deletes old chunk keys when updating (previous root present)", async () => {
+    const oldHash = "deadbeef";
+    vi.mocked(getPreferences).mockResolvedValue({
+      "P:root": oldHash,
+      [`P:${oldHash}`]: "old chunk",
+    });
+    vi.mocked(updatePreferences).mockResolvedValue();
+    vi.mocked(deletePreferences).mockResolvedValue();
+
+    await setChunkedPreference("P", "new");
+
+    expect(deletePreferences).toHaveBeenCalledWith(`P:${oldHash}`, undefined);
+  });
+
+  it("deletes orphan chunk keys (not in previous or new root) on write", async () => {
+    vi.mocked(getPreferences).mockResolvedValue({
+      "P:root": "aaaaaaaa",
+      "P:aaaaaaaa": "chunk",
+      "P:deadbeef": "orphan chunk from failed write",
+    });
+    vi.mocked(updatePreferences).mockResolvedValue();
+    const deletedKeys: string[] = [];
+    vi.mocked(deletePreferences).mockImplementation(async (key) => {
+      deletedKeys.push(key);
+    });
+
+    await setChunkedPreference("P", "x");
+
+    expect(deletedKeys).toContain("P:deadbeef");
+  });
+
+  it("retries chunk PUT on failure and eventually succeeds", async () => {
+    let chunkPutCount = 0;
+    vi.mocked(getPreferences).mockResolvedValue({});
+    vi.mocked(updatePreferences).mockImplementation(async (key, value) => {
+      if (key !== "P:root") {
+        chunkPutCount++;
+        if (chunkPutCount <= 2) throw new Error("network");
+      }
+    });
+    vi.mocked(deletePreferences).mockResolvedValue();
+
+    await setChunkedPreference("P", "y");
+
+    expect(chunkPutCount).toBe(3);
+  });
+
+  it("throws when chunk PUT fails after all retries", async () => {
+    vi.mocked(getPreferences).mockResolvedValue({});
+    vi.mocked(updatePreferences).mockImplementation(async (key) => {
+      if (key !== "P:root") throw new Error("network");
+    });
+    vi.mocked(deletePreferences).mockResolvedValue();
+
+    await expect(setChunkedPreference("P", "z")).rejects.toThrow("network");
+  });
+});

--- a/src/api/preferences/__tests__/setChunkedPreference.test.ts
+++ b/src/api/preferences/__tests__/setChunkedPreference.test.ts
@@ -22,7 +22,7 @@ describe("setChunkedPreference", () => {
     expect(updateCalls.length).toBeGreaterThanOrEqual(2);
     const rootCall = updateCalls.find(([k]) => k === "P:root");
     expect(rootCall).toBeDefined();
-    expect(updateCalls[updateCalls.length - 1]![0]).toBe("P:root");
+    expect(updateCalls.at(-1)?.[0]).toBe("P:root");
     const chunkCalls = updateCalls.slice(0, -1);
     expect(
       chunkCalls.every(([k]) => k.startsWith("P:") && k !== "P:root")
@@ -64,7 +64,7 @@ describe("setChunkedPreference", () => {
   it("retries chunk PUT on failure and eventually succeeds", async () => {
     let chunkPutCount = 0;
     vi.mocked(getPreferences).mockResolvedValue({});
-    vi.mocked(updatePreferences).mockImplementation(async (key, value) => {
+    vi.mocked(updatePreferences).mockImplementation(async (key) => {
       if (key !== "P:root") {
         chunkPutCount++;
         if (chunkPutCount <= 2) throw new Error("network");

--- a/src/api/preferences/__tests__/updatePreference.test.ts
+++ b/src/api/preferences/__tests__/updatePreference.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import * as getPreferencesModule from "../getPreferences";
+import { updatePreference } from "../updatePreference";
+
+vi.mock("../getPreferences", () => ({
+  getPreferences: vi.fn(),
+}));
+
+describe("updatePreference", () => {
+  it("throws when key contains disallowed character (e.g. /)", async () => {
+    await expect(
+      updatePreference("key/with/slash", { x: 1 })
+    ).rejects.toThrow(/Preference key must not contain.*unsafe in URL path/);
+  });
+
+  it("throws when storage auto and key exists as both single and split", async () => {
+    vi.mocked(getPreferencesModule.getPreferences).mockResolvedValue({
+      P: "single",
+      "P:root": "h1",
+      "P:h1": "chunk",
+    });
+    await expect(updatePreference("P", { x: 1 })).rejects.toThrow(
+      /exists as both a single key and split storage/
+    );
+  });
+});

--- a/src/api/preferences/__tests__/updatePreference.test.ts
+++ b/src/api/preferences/__tests__/updatePreference.test.ts
@@ -1,16 +1,28 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { deletePreferences } from "../deletePreferences";
 import * as getPreferencesModule from "../getPreferences";
+import { updatePreferences } from "../updatePreferences";
 import { updatePreference } from "../updatePreference";
 
 vi.mock("../getPreferences", () => ({
   getPreferences: vi.fn(),
 }));
+vi.mock("../updatePreferences", () => ({
+  updatePreferences: vi.fn(),
+}));
+vi.mock("../deletePreferences", () => ({
+  deletePreferences: vi.fn(),
+}));
 
 describe("updatePreference", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("throws when key contains disallowed character (e.g. /)", async () => {
-    await expect(
-      updatePreference("key/with/slash", { x: 1 })
-    ).rejects.toThrow(/Preference key must not contain.*unsafe in URL path/);
+    await expect(updatePreference("key/with/slash", { x: 1 })).rejects.toThrow(
+      /Preference key must not contain.*unsafe in URL path/
+    );
   });
 
   it("throws when storage auto and key exists as both single and split", async () => {
@@ -22,5 +34,43 @@ describe("updatePreference", () => {
     await expect(updatePreference("P", { x: 1 })).rejects.toThrow(
       /exists as both a single key and split storage/
     );
+  });
+
+  it("auto writes single and removes previous split storage", async () => {
+    vi.mocked(getPreferencesModule.getPreferences).mockResolvedValue({
+      "P:root": "aaaaaaaa",
+      "P:aaaaaaaa": "old chunk",
+    });
+    vi.mocked(updatePreferences).mockResolvedValue();
+    vi.mocked(deletePreferences).mockResolvedValue();
+
+    await updatePreference("P", { x: 1 }, { storage: "auto" });
+
+    expect(updatePreferences).toHaveBeenCalledWith(
+      "P",
+      JSON.stringify({ x: 1 }),
+      { storage: "auto" }
+    );
+    expect(deletePreferences).toHaveBeenCalledWith("P:root", {
+      storage: "auto",
+    });
+    expect(deletePreferences).toHaveBeenCalledWith("P:aaaaaaaa", {
+      storage: "auto",
+    });
+  });
+
+  it("auto writes split and removes previous single key", async () => {
+    vi.mocked(getPreferencesModule.getPreferences).mockResolvedValue({
+      P: "old-single",
+    });
+    vi.mocked(updatePreferences).mockResolvedValue();
+    vi.mocked(deletePreferences).mockResolvedValue();
+
+    await updatePreference("P", { data: "x".repeat(300) }, { storage: "auto" });
+
+    expect(
+      vi.mocked(updatePreferences).mock.calls.some(([key]) => key === "P:root")
+    ).toBe(true);
+    expect(deletePreferences).toHaveBeenCalledWith("P", { storage: "auto" });
   });
 });

--- a/src/api/preferences/chunked.ts
+++ b/src/api/preferences/chunked.ts
@@ -1,0 +1,478 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type { Tags } from "../../types";
+import type { FetchOptions } from "../_osmFetch";
+import { deletePreferences } from "./deletePreferences";
+import { getPreferences } from "./getPreferences";
+import { updatePreferences } from "./updatePreferences";
+
+/**
+ * Result of a validated preference read (single key or split). Use with the
+ * schema overload of {@link getPreference}.
+ * - `null`: No stored data or read failed (missing key or split root/chunk).
+ * - `{ value: T }`: Stored value was valid JSON and passed schema validation.
+ * - `{ issues }`: Stored value was present but JSON parse or schema validation failed.
+ * @internal Prefer {@link PreferenceResult} in public API.
+ */
+export type ChunkedPreferenceResult<T> =
+  | { value: T }
+  | { issues: readonly StandardSchemaV1.Issue[] }
+  | null;
+
+/** Alias of {@link ChunkedPreferenceResult}. Result of getPreference with schema. */
+export type PreferenceResult<T> = ChunkedPreferenceResult<T>;
+
+const VALUE_LIMIT = 255;
+const HASH_LENGTH = 8;
+/** Max hashes that fit in root value (255 chars): each hash 8 chars + comma */
+const MAX_CHUNKS = Math.floor(VALUE_LIMIT / (HASH_LENGTH + 1));
+const MAX_PAYLOAD_BYTES = MAX_CHUNKS * VALUE_LIMIT;
+
+/** Characters disallowed in preference keys (unsafe in URL path). */
+const PREFERENCE_KEY_DISALLOWED = /[/?#\\]/;
+
+/**
+ * Validates that a preference key does not contain characters unsafe in the OSM API path.
+ * @throws If key contains / ? # or \\
+ */
+export function assertPreferenceKey(key: string): void {
+  if (PREFERENCE_KEY_DISALLOWED.test(key)) {
+    throw new Error(
+      `Preference key must not contain / ? # or \\ (unsafe in URL path): "${key}"`
+    );
+  }
+}
+
+/** @internal First 8 hex chars of SHA-256 of content. Same algorithm in Swift etc. for interoperability. */
+async function chunkHash(content: string): Promise<string> {
+  const buf = await globalThis.crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(content)
+  );
+  const hex = [...new Uint8Array(buf)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return hex.slice(0, HASH_LENGTH);
+}
+
+function rootKey(prefix: string): string {
+  return `${prefix}:root`;
+}
+
+function chunkKey(prefix: string, hash: string): string {
+  return `${prefix}:${hash}`;
+}
+
+/** True if key is a chunk key for prefix (prefix:8hex). */
+function isChunkKeyForPrefix(key: string, prefix: string): boolean {
+  const suffix = prefix.length + 1;
+  return (
+    key.startsWith(prefix + ":") &&
+    key.length === suffix + HASH_LENGTH &&
+    /^[\da-f]{8}$/i.test(key.slice(suffix))
+  );
+}
+
+function unpackChunkedRaw(preferences: Tags, prefix: string): string | null {
+  const root = preferences[rootKey(prefix)];
+  if (root === undefined || root === "") {
+    return null;
+  }
+  const hashes = root.split(",").filter(Boolean);
+  const parts: string[] = [];
+  for (const h of hashes) {
+    const key = chunkKey(prefix, h);
+    const chunk = preferences[key];
+    if (chunk === undefined) {
+      return null;
+    }
+    parts.push(chunk);
+  }
+  return parts.join("");
+}
+
+/** Storage mode for single-key preference ops: auto (detect/by length), single (one API key), split (multiple keys). */
+export type StorageMode = "auto" | "single" | "split";
+
+/** Whether the map has a single key for this logical preference. */
+export function hasSingleKey(preferences: Tags, key: string): boolean {
+  return key in preferences;
+}
+
+/** Whether the map has split storage for this logical preference (prefix:root present). */
+export function hasSplitKey(preferences: Tags, key: string): boolean {
+  return rootKey(key) in preferences;
+}
+
+/**
+ * Resolve the string value for a key from a preferences map according to storage mode.
+ * @throws If storage is 'auto' and both single and split are present (conflict).
+ */
+export function resolveValueForKey(
+  preferences: Tags,
+  key: string,
+  storage: StorageMode
+): string | null {
+  const single = hasSingleKey(preferences, key);
+  const split = hasSplitKey(preferences, key);
+  if (storage === "single") {
+    return single ? (preferences[key] ?? null) : null;
+  }
+  if (storage === "split") {
+    return unpackChunkedRaw(preferences, key);
+  }
+  // auto
+  if (single && split) {
+    throw new Error(
+      `Preference "${key}" exists as both a single key and split storage. Set storage: 'single' or 'split' to resolve.`
+    );
+  }
+  if (single) return preferences[key] ?? null;
+  if (split) return unpackChunkedRaw(preferences, key);
+  return null;
+}
+
+export interface PackChunkedResult {
+  rootKey: string;
+  rootValue: string;
+  chunks: Record<string, string>;
+  oldKeysToDelete: string[];
+}
+
+/**
+ * Splits a value into multiple preference entries (split storage). Use with
+ * {@link unpackChunked} for round-trip. Safe write order: write all `chunks` in
+ * parallel (with retries), then `rootKey`/`rootValue`, then `oldKeysToDelete`.
+ * Chunks-first so readers never see a root pointing to missing chunks.
+ *
+ * @param prefix - Logical key (e.g. `ESS`, `ESS:editor-settings`). URL-safe.
+ * @param value - String to store. Must not exceed {@link packChunked.MAX_PAYLOAD_BYTES}.
+ * @param previousRootValue - Comma-separated hashes from previous root; used to compute `oldKeysToDelete`.
+ * @param valueLimit - Max chars per chunk. Default 255 (OSM limit).
+ * @returns Keys/values to write and keys to delete after updating root.
+ * @throws If value length exceeds {@link packChunked.MAX_PAYLOAD_BYTES}.
+ */
+export async function packChunked(
+  prefix: string,
+  value: string,
+  previousRootValue?: string,
+  valueLimit: number = VALUE_LIMIT
+): Promise<PackChunkedResult> {
+  if (value.length > MAX_PAYLOAD_BYTES) {
+    throw new Error(
+      `Preference value exceeds maximum size (${MAX_PAYLOAD_BYTES} bytes). Use a shorter value or split across multiple prefixes.`
+    );
+  }
+
+  const numberChunks =
+    value.length === 0 ? 1 : Math.ceil(value.length / valueLimit);
+  const chunkStrings = Array.from({ length: numberChunks }, (_, index) =>
+    value.slice(index * valueLimit, (index + 1) * valueLimit)
+  );
+
+  const hashes: string[] = [];
+  const chunks: Record<string, string> = {};
+  for (const chunk of chunkStrings) {
+    const h = await chunkHash(chunk);
+    hashes.push(h);
+    chunks[chunkKey(prefix, h)] = chunk;
+  }
+
+  const rootValue = hashes.join(",");
+  const previousHashes = previousRootValue
+    ? previousRootValue.split(",").filter(Boolean)
+    : [];
+  const newSet = new Set(hashes);
+  const oldKeysToDelete = previousHashes
+    .filter((h) => !newSet.has(h))
+    .map((h) => chunkKey(prefix, h));
+
+  return {
+    rootKey: rootKey(prefix),
+    rootValue,
+    chunks,
+    oldKeysToDelete,
+  };
+}
+
+/** Max payload size in characters. Check before calling to avoid throwing. */
+packChunked.MAX_PAYLOAD_BYTES = MAX_PAYLOAD_BYTES;
+
+/** Max length (chars) for one logical preference when stored as split. */
+export const PREFERENCE_SPLIT_MAX_PAYLOAD_BYTES = MAX_PAYLOAD_BYTES;
+
+/** Number of attempts (including initial) for each chunk PUT when writing split storage. */
+const CHUNK_PUT_ATTEMPTS = 3;
+
+/** Parse JSON and validate with schema; return result or issues. Used by getPreference and split reads. */
+export async function validatePreferenceValue<S extends StandardSchemaV1>(
+  raw: string,
+  schema: S
+): Promise<PreferenceResult<StandardSchemaV1.InferOutput<S>>> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {
+      issues: [{ message: "Invalid JSON" }],
+    };
+  }
+  const result = await Promise.resolve(schema["~standard"].validate(parsed));
+  if ("value" in result) {
+    return { value: result.value };
+  }
+  return { issues: result.issues };
+}
+
+async function validateChunkedRaw<S extends StandardSchemaV1>(
+  raw: string,
+  schema: S
+): Promise<ChunkedPreferenceResult<StandardSchemaV1.InferOutput<S>>> {
+  return validatePreferenceValue(raw, schema);
+}
+
+/**
+ * Reads a split-storage preference from a preferences map. Returns the concatenated
+ * string or `null` if no root or a chunk is missing.
+ *
+ * @param preferences - Result of {@link getPreferences}.
+ * @param prefix - Same prefix used when writing.
+ */
+export function unpackChunked(preferences: Tags, prefix: string): string | null;
+
+/**
+ * Reads a split-storage preference and validates it with a schema. Stored value is
+ * assumed to be JSON. Use when you already have a preferences map (e.g. from
+ * {@link getPreferences}) and want typed, validated output without an extra fetch.
+ *
+ * @param preferences - Result of {@link getPreferences}.
+ * @param prefix - Same prefix used when writing.
+ * @param schema - Any [Standard Schema](https://github.com/standard-schema/standard-schema) implementation (e.g. Zod 4, Valibot).
+ * @returns `{ value }` on success, `{ issues }` on parse/validation failure, or `null` if no data or chunk missing.
+ */
+export function unpackChunked<S extends StandardSchemaV1>(
+  preferences: Tags,
+  prefix: string,
+  schema: S
+): Promise<ChunkedPreferenceResult<StandardSchemaV1.InferOutput<S>>>;
+
+export function unpackChunked(
+  preferences: Tags,
+  prefix: string,
+  schema?: StandardSchemaV1
+): string | null | Promise<ChunkedPreferenceResult<unknown>> {
+  const raw = unpackChunkedRaw(preferences, prefix);
+  if (raw === null) return null;
+  if (schema !== undefined) return validateChunkedRaw(raw, schema);
+  return raw;
+}
+
+/**
+ * Fetches and reassembles a split-storage preference (root + chunks).
+ *
+ * @param prefix - Logical key used when storing.
+ * @returns The stored string, or `null` if not set or corrupted.
+ */
+export async function getChunkedPreference(
+  prefix: string,
+  options?: FetchOptions
+): Promise<string | null>;
+
+/**
+ * Fetches and reassembles a split-storage preference, then parses JSON and validates
+ * with a schema. Stored value is assumed to be JSON; store with
+ * `JSON.stringify(...)` (or validate then stringify) for round-trip. Pass any
+ * [Standard Schema](https://github.com/standard-schema/standard-schema) implementation
+ * (e.g. Zod 4, Valibot).
+ *
+ * @param prefix - Logical key used when storing.
+ * @param schema - Schema to validate and infer output type.
+ * @param options - Optional fetch options.
+ * @returns `{ value: T }` on success, `{ issues }` on parse/validation failure, or `null` if no data or chunk missing.
+ */
+export async function getChunkedPreference<S extends StandardSchemaV1>(
+  prefix: string,
+  schema: S,
+  options?: FetchOptions
+): Promise<ChunkedPreferenceResult<StandardSchemaV1.InferOutput<S>>>;
+
+export async function getChunkedPreference(
+  prefix: string,
+  schemaOrOptions?: StandardSchemaV1 | FetchOptions,
+  options?: FetchOptions
+): Promise<string | null | ChunkedPreferenceResult<unknown>> {
+  assertPreferenceKey(prefix);
+  const isSchema =
+    schemaOrOptions !== undefined &&
+    typeof schemaOrOptions === "object" &&
+    schemaOrOptions !== null &&
+    "~standard" in schemaOrOptions;
+  const schema = isSchema ? (schemaOrOptions as StandardSchemaV1) : undefined;
+  const fetchOptions =
+    schema === undefined ? (schemaOrOptions as FetchOptions) : options;
+  const preferences = await getPreferences({
+    ...fetchOptions,
+    handleStorage: "raw",
+  });
+  const raw = unpackChunkedRaw(preferences, prefix);
+  if (raw === null) return null;
+  if (schema !== undefined) return validateChunkedRaw(raw, schema);
+  return raw;
+}
+
+/**
+ * Writes one chunk with retries. Used by setChunkedPreference so chunk PUTs can
+ * be retried on transient network errors.
+ */
+async function putChunkWithRetry(
+  key: string,
+  chunkValue: string,
+  options: FetchOptions | undefined,
+  attempts: number
+): Promise<void> {
+  let lastErr: unknown;
+  let attempt = 0;
+  while (attempt < attempts) {
+    try {
+      await updatePreferences(key, chunkValue, options);
+      return;
+    } catch (e) {
+      lastErr = e;
+      attempt++;
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Stores a value as a split-storage preference (root + chunks). Write order:
+ * all chunks in parallel (each chunk retried up to 3 times), then root, then
+ * delete old chunk keys. Chunks-first so readers never see a root without all
+ * chunks present. Check
+ * `value.length <= packChunked.MAX_PAYLOAD_BYTES` before calling to avoid throwing.
+ *
+ * @param prefix - Logical key (e.g. `ESS:editor-settings`).
+ * @param value - String to store.
+ * @throws If value length exceeds {@link packChunked.MAX_PAYLOAD_BYTES}.
+ * @throws If any chunk write or root write fails after retries; some chunk
+ * keys may be written (orphans) but root is not, so readers see previous state.
+ */
+export async function setChunkedPreference(
+  prefix: string,
+  value: string,
+  options?: FetchOptions
+): Promise<void> {
+  assertPreferenceKey(prefix);
+  const preferences = await getPreferences({
+    ...options,
+    handleStorage: "raw",
+  });
+  const previousRoot = preferences[rootKey(prefix)];
+
+  const {
+    rootKey: rk,
+    rootValue: rv,
+    chunks,
+    oldKeysToDelete,
+  } = await packChunked(prefix, value, previousRoot);
+
+  const newHashes = new Set(rv.split(",").filter(Boolean));
+  const orphanChunkKeys = Object.keys(preferences).filter(
+    (k) => isChunkKeyForPrefix(k, prefix) && !newHashes.has(k.slice(prefix.length + 1))
+  );
+  const keysToDelete = [...new Set([...oldKeysToDelete, ...orphanChunkKeys])];
+
+  await Promise.all(
+    Object.entries(chunks).map(([key, chunkValue]) =>
+      putChunkWithRetry(key, chunkValue, options, CHUNK_PUT_ATTEMPTS)
+    )
+  );
+  await updatePreferences(rk, rv, options);
+
+  for (const key of keysToDelete) {
+    await deletePreferences(key, options);
+  }
+}
+
+/**
+ * Removes a split-storage preference: deletes root and all its chunks.
+ */
+export async function deleteChunkedPreference(
+  prefix: string,
+  options?: FetchOptions
+): Promise<void> {
+  assertPreferenceKey(prefix);
+  const preferences = await getPreferences({
+    ...options,
+    handleStorage: "raw",
+  });
+  const root = preferences[rootKey(prefix)];
+  if (root === undefined || root === "") {
+    return;
+  }
+  const hashes = root.split(",").filter(Boolean);
+  await deletePreferences(rootKey(prefix), options);
+  for (const h of hashes) {
+    await deletePreferences(chunkKey(prefix, h), options);
+  }
+}
+
+/**
+ * Builds a logical key map from raw preferences: each split prefix (X:root + X:hash*)
+ * becomes one entry X → concatenated value; other keys are passed through.
+ * Used by getPreferences (default merged). Chunk keys are identified as prefix + ":"
+ * + 8 hex chars for any prefix that has a ":root" key (so logical keys can contain ":").
+ */
+export function mergePreferencesToLogical(
+  preferences: Tags
+): Record<string, string> {
+  const merged: Record<string, string> = {};
+  const rootPrefixes = Object.keys(preferences)
+    .filter((k) => k.endsWith(":root"))
+    .map((k) => k.slice(0, -5));
+  for (const key of Object.keys(preferences)) {
+    if (key.endsWith(":root")) {
+      const prefix = key.slice(0, -5);
+      const value = unpackChunkedRaw(preferences, prefix);
+      if (value !== null) {
+        merged[prefix] = value;
+      }
+    } else if (
+      !rootPrefixes.some((prefix) => isChunkKeyForPrefix(key, prefix))
+    ) {
+      const v = preferences[key];
+      if (v !== undefined) {
+        merged[key] = v;
+      }
+    }
+  }
+  return merged;
+}
+
+/**
+ * Writes a preference value according to storage mode. Used by updatePreference.
+ * @throws If storage is 'single' and value length exceeds 255.
+ */
+export async function writePreferenceValue(
+  key: string,
+  value: string,
+  storage: StorageMode,
+  options?: FetchOptions
+): Promise<void> {
+  if (storage === "single") {
+    if (value.length > VALUE_LIMIT) {
+      throw new Error(
+        "Preference value exceeds 255 characters (OSM limit). Use storage: 'auto' or 'split' for longer values."
+      );
+    }
+    await updatePreferences(key, value, options);
+    return;
+  }
+  if (storage === "split") {
+    await setChunkedPreference(key, value, options);
+    return;
+  }
+  // auto
+  await (value.length <= VALUE_LIMIT
+    ? updatePreferences(key, value, options)
+    : setChunkedPreference(key, value, options));
+}

--- a/src/api/preferences/chunked.ts
+++ b/src/api/preferences/chunked.ts
@@ -28,7 +28,7 @@ const MAX_CHUNKS = Math.floor(VALUE_LIMIT / (HASH_LENGTH + 1));
 const MAX_PAYLOAD_BYTES = MAX_CHUNKS * VALUE_LIMIT;
 
 /** Characters disallowed in preference keys (unsafe in URL path). */
-const PREFERENCE_KEY_DISALLOWED = /[/?#\\]/;
+const PREFERENCE_KEY_DISALLOWED = /[#/?\\]/;
 
 /**
  * Validates that a preference key does not contain characters unsafe in the OSM API path.
@@ -66,7 +66,7 @@ function chunkKey(prefix: string, hash: string): string {
 function isChunkKeyForPrefix(key: string, prefix: string): boolean {
   const suffix = prefix.length + 1;
   return (
-    key.startsWith(prefix + ":") &&
+    key.startsWith(`${prefix}:`) &&
     key.length === suffix + HASH_LENGTH &&
     /^[\da-f]{8}$/i.test(key.slice(suffix))
   );
@@ -329,18 +329,18 @@ async function putChunkWithRetry(
   options: FetchOptions | undefined,
   attempts: number
 ): Promise<void> {
-  let lastErr: unknown;
+  let lastError: unknown;
   let attempt = 0;
   while (attempt < attempts) {
     try {
       await updatePreferences(key, chunkValue, options);
       return;
-    } catch (e) {
-      lastErr = e;
+    } catch (error) {
+      lastError = error;
       attempt++;
     }
   }
-  throw lastErr;
+  throw lastError;
 }
 
 /**
@@ -377,7 +377,9 @@ export async function setChunkedPreference(
 
   const newHashes = new Set(rv.split(",").filter(Boolean));
   const orphanChunkKeys = Object.keys(preferences).filter(
-    (k) => isChunkKeyForPrefix(k, prefix) && !newHashes.has(k.slice(prefix.length + 1))
+    (k) =>
+      isChunkKeyForPrefix(k, prefix) &&
+      !newHashes.has(k.slice(prefix.length + 1))
   );
   const keysToDelete = [...new Set([...oldKeysToDelete, ...orphanChunkKeys])];
 
@@ -426,25 +428,36 @@ export function mergePreferencesToLogical(
   preferences: Tags
 ): Record<string, string> {
   const merged: Record<string, string> = {};
-  const rootPrefixes = Object.keys(preferences)
-    .filter((k) => k.endsWith(":root"))
-    .map((k) => k.slice(0, -5));
+  const rootPrefixes = new Set(
+    Object.keys(preferences)
+      .filter((k) => k.endsWith(":root"))
+      .map((k) => k.slice(0, -5))
+  );
+  const rootPrefixList = [...rootPrefixes];
+
+  // First pass: include plain single keys (exclude split chunks/root keys).
   for (const key of Object.keys(preferences)) {
-    if (key.endsWith(":root")) {
-      const prefix = key.slice(0, -5);
-      const value = unpackChunkedRaw(preferences, prefix);
-      if (value !== null) {
-        merged[prefix] = value;
-      }
-    } else if (
-      !rootPrefixes.some((prefix) => isChunkKeyForPrefix(key, prefix))
-    ) {
-      const v = preferences[key];
-      if (v !== undefined) {
-        merged[key] = v;
+    if (key.endsWith(":root")) continue;
+
+    const isChunkKey = rootPrefixList.some((prefix) =>
+      isChunkKeyForPrefix(key, prefix)
+    );
+    if (!isChunkKey) {
+      const value = preferences[key];
+      if (value !== undefined) {
+        merged[key] = value;
       }
     }
   }
+
+  // Second pass: merge split keys and deterministically override single keys.
+  for (const prefix of rootPrefixes) {
+    const value = unpackChunkedRaw(preferences, prefix);
+    if (value !== null) {
+      merged[prefix] = value;
+    }
+  }
+
   return merged;
 }
 

--- a/src/api/preferences/deletePreference.ts
+++ b/src/api/preferences/deletePreference.ts
@@ -1,0 +1,51 @@
+import type { FetchOptions } from "../_osmFetch";
+import type { StorageMode } from "./chunked";
+import {
+  assertPreferenceKey,
+  deleteChunkedPreference,
+  hasSingleKey,
+  hasSplitKey,
+} from "./chunked";
+import { deletePreferences } from "./deletePreferences";
+import { getPreferences } from "./getPreferences";
+
+export interface DeletePreferenceOptions extends FetchOptions {
+  /** What to remove: 'auto' (both single and split if present), 'single' (one API key only), 'split' (split storage only). Default 'auto'. */
+  storage?: StorageMode;
+}
+
+/**
+ * Deletes a single preference. Per storage mode: 'auto' removes both single key and split keys if present;
+ * 'single' removes only the single key; 'split' removes only the split storage (root + chunks).
+ *
+ * @param key - Logical preference key.
+ * @param options - Optional storage mode and fetch options.
+ */
+export async function deletePreference(
+  key: string,
+  options?: DeletePreferenceOptions
+): Promise<void> {
+  assertPreferenceKey(key);
+  const storage = options?.storage ?? "auto";
+  const preferences = await getPreferences({
+    ...options,
+    handleStorage: "raw",
+  });
+  if (storage === "single") {
+    if (hasSingleKey(preferences, key)) {
+      await deletePreferences(key, options);
+    }
+    return;
+  }
+  if (storage === "split") {
+    await deleteChunkedPreference(key, options);
+    return;
+  }
+  // auto: remove both
+  if (hasSingleKey(preferences, key)) {
+    await deletePreferences(key, options);
+  }
+  if (hasSplitKey(preferences, key)) {
+    await deleteChunkedPreference(key, options);
+  }
+}

--- a/src/api/preferences/getPreference.ts
+++ b/src/api/preferences/getPreference.ts
@@ -1,0 +1,52 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type { FetchOptions } from "../_osmFetch";
+import type { PreferenceResult, StorageMode } from "./chunked";
+import {
+  assertPreferenceKey,
+  resolveValueForKey,
+  validatePreferenceValue,
+} from "./chunked";
+import { getPreferences } from "./getPreferences";
+
+export interface GetPreferenceOptions extends FetchOptions {
+  /** How to resolve the key: 'auto' (detect), 'single' (one API key), 'split' (multiple keys). Default 'auto'. */
+  storage?: StorageMode;
+  /** If provided, stored value is parsed as JSON and validated; returns PreferenceResult. */
+  schema?: StandardSchemaV1;
+}
+
+/**
+ * Gets a single preference by key. Resolves single vs split storage per `storage` option.
+ * With `schema`, parses JSON and validates; returns `PreferenceResult<T>`. Without schema, returns raw string or null.
+ *
+ * @param key - Logical preference key.
+ * @param options - Optional storage mode, schema, and fetch options.
+ * @returns With schema: `{ value }` | `{ issues }` | null. Without schema: string | null.
+ * @throws If storage is 'auto' and the key exists as both single and split (conflict).
+ */
+export async function getPreference(
+  key: string,
+  options?: GetPreferenceOptions
+): Promise<string | null>;
+
+export async function getPreference<S extends StandardSchemaV1>(
+  key: string,
+  options: GetPreferenceOptions & { schema: S }
+): Promise<PreferenceResult<StandardSchemaV1.InferOutput<S>>>;
+
+export async function getPreference(
+  key: string,
+  options?: GetPreferenceOptions
+): Promise<string | null | PreferenceResult<unknown>> {
+  assertPreferenceKey(key);
+  const storage = options?.storage ?? "auto";
+  const schema = options?.schema;
+  const preferences = await getPreferences({
+    ...options,
+    handleStorage: "raw",
+  });
+  const raw = resolveValueForKey(preferences, key, storage);
+  if (raw === null) return null;
+  if (schema !== undefined) return validatePreferenceValue(raw, schema);
+  return raw;
+}

--- a/src/api/preferences/getPreferences.ts
+++ b/src/api/preferences/getPreferences.ts
@@ -1,12 +1,32 @@
 import type { Tags } from "../../types";
 import { type FetchOptions, osmFetch } from "../_osmFetch";
+import { mergePreferencesToLogical } from "./chunked";
 
-export async function getPreferences(options?: FetchOptions): Promise<Tags> {
+/** How storage appears in the output: raw (API as-is) or merged (one entry per logical preference). */
+export type HandleStorage = "raw" | "merged";
+
+export interface GetPreferencesOptions extends FetchOptions {
+  /** Default 'merged'. Use 'raw' to get API keys as returned (including split keys). */
+  handleStorage?: HandleStorage;
+}
+
+/**
+ * Fetches all preferences for the logged-in user. OSM API returns full key-value only.
+ *
+ * @param options - Optional handleStorage ('raw' | 'merged') and fetch options.
+ * @returns Record<string, string> with logical keys (default merged), or raw Tags when handleStorage is 'raw'.
+ */
+export async function getPreferences(
+  options?: GetPreferencesOptions
+): Promise<Record<string, string> | Tags> {
   const raw = await osmFetch<{ preferences: Tags }>(
     "/0.6/user/preferences.json",
     undefined,
     options
   );
-
-  return raw.preferences;
+  const prefs = raw.preferences;
+  if (options?.handleStorage === "raw") {
+    return prefs;
+  }
+  return mergePreferencesToLogical(prefs);
 }

--- a/src/api/preferences/index.ts
+++ b/src/api/preferences/index.ts
@@ -1,3 +1,11 @@
+export {
+  StorageMode,
+  PreferenceResult,
+  PREFERENCE_SPLIT_MAX_PAYLOAD_BYTES,
+} from "./chunked";
+export * from "./deletePreference";
 export * from "./deletePreferences";
+export * from "./getPreference";
 export * from "./getPreferences";
+export * from "./updatePreference";
 export * from "./updatePreferences";

--- a/src/api/preferences/index.ts
+++ b/src/api/preferences/index.ts
@@ -1,8 +1,5 @@
-export {
-  StorageMode,
-  PreferenceResult,
-  PREFERENCE_SPLIT_MAX_PAYLOAD_BYTES,
-} from "./chunked";
+export { PREFERENCE_SPLIT_MAX_PAYLOAD_BYTES } from "./chunked";
+export type { PreferenceResult, StorageMode } from "./chunked";
 export * from "./deletePreference";
 export * from "./deletePreferences";
 export * from "./getPreference";

--- a/src/api/preferences/updatePreference.ts
+++ b/src/api/preferences/updatePreference.ts
@@ -1,0 +1,61 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type { FetchOptions } from "../_osmFetch";
+import type { StorageMode } from "./chunked";
+import {
+  assertPreferenceKey,
+  hasSingleKey,
+  hasSplitKey,
+  writePreferenceValue,
+} from "./chunked";
+import { getPreferences } from "./getPreferences";
+
+export interface UpdatePreferenceOptions extends FetchOptions {
+  /** How to store: 'auto' (by length), 'single' (one API key, error if >255), 'split' (multiple keys). Default 'auto'. */
+  storage?: StorageMode;
+  /** If provided, value is validated before writing. */
+  schema?: StandardSchemaV1;
+}
+
+/**
+ * Writes a single preference. Value is JSON-serialized. With schema, value is validated first.
+ * Storage mode: 'auto' uses single key if serialized length ≤255 else split; 'single' errors if >255; 'split' always uses split storage.
+ *
+ * @param key - Logical preference key.
+ * @param value - Value to store (object, array, string, number, boolean). Will be JSON.stringify'd.
+ * @param options - Optional storage mode, schema, and fetch options.
+ * @throws If schema validation fails. If storage is 'single' and serialized value exceeds 255 chars. If storage is 'auto' and the key exists as both single and split (conflict).
+ */
+export async function updatePreference(
+  key: string,
+  value: unknown,
+  options?: UpdatePreferenceOptions
+): Promise<void> {
+  assertPreferenceKey(key);
+  const storage = options?.storage ?? "auto";
+  const schema = options?.schema;
+  let serialized: string;
+  if (schema === undefined) {
+    serialized = JSON.stringify(value);
+  } else {
+    const result = await Promise.resolve(schema["~standard"].validate(value));
+    if ("value" in result) {
+      serialized = JSON.stringify(result.value);
+    } else {
+      throw new Error(
+        `Preference validation failed: ${JSON.stringify(result.issues)}`
+      );
+    }
+  }
+  if (storage === "auto") {
+    const preferences = await getPreferences({
+      ...options,
+      handleStorage: "raw",
+    });
+    if (hasSingleKey(preferences, key) && hasSplitKey(preferences, key)) {
+      throw new Error(
+        `Preference "${key}" exists as both a single key and split storage. Set storage: 'single' or 'split' to resolve.`
+      );
+    }
+  }
+  await writePreferenceValue(key, serialized, storage, options);
+}

--- a/src/api/preferences/updatePreference.ts
+++ b/src/api/preferences/updatePreference.ts
@@ -3,10 +3,12 @@ import type { FetchOptions } from "../_osmFetch";
 import type { StorageMode } from "./chunked";
 import {
   assertPreferenceKey,
+  deleteChunkedPreference,
   hasSingleKey,
   hasSplitKey,
   writePreferenceValue,
 } from "./chunked";
+import { deletePreferences } from "./deletePreferences";
 import { getPreferences } from "./getPreferences";
 
 export interface UpdatePreferenceOptions extends FetchOptions {
@@ -46,16 +48,31 @@ export async function updatePreference(
       );
     }
   }
-  if (storage === "auto") {
-    const preferences = await getPreferences({
-      ...options,
-      handleStorage: "raw",
-    });
-    if (hasSingleKey(preferences, key) && hasSplitKey(preferences, key)) {
-      throw new Error(
-        `Preference "${key}" exists as both a single key and split storage. Set storage: 'single' or 'split' to resolve.`
-      );
-    }
+  const preferences = await getPreferences({
+    ...options,
+    handleStorage: "raw",
+  });
+  const singleExists = hasSingleKey(preferences, key);
+  const splitExists = hasSplitKey(preferences, key);
+
+  if (storage === "auto" && singleExists && splitExists) {
+    throw new Error(
+      `Preference "${key}" exists as both a single key and split storage. Set storage: 'single' or 'split' to resolve.`
+    );
   }
-  await writePreferenceValue(key, serialized, storage, options);
+
+  const targetStorage: Exclude<StorageMode, "auto"> =
+    storage === "auto"
+      ? serialized.length <= 255
+        ? "single"
+        : "split"
+      : storage;
+
+  await writePreferenceValue(key, serialized, targetStorage, options);
+
+  if (targetStorage === "single" && splitExists) {
+    await deleteChunkedPreference(key, options);
+  } else if (targetStorage === "split" && singleExists) {
+    await deletePreferences(key, options);
+  }
 }


### PR DESCRIPTION
I looked into how to implement https://github.com/osmlab/osm-api-js/issues/32

The discussion at https://github.com/openstreetmap/openstreetmap-website/pull/6399#issuecomment-3714407205 does not sound like a large limit will happen or at least not any time soon. Based on this, having tooling that handles the splitting / chucking will be very usefull.

This PR implements what @k-yle suggested in https://github.com/osmlab/osm-api-js/issues/32#issuecomment-3660625648 - the way I understood it.

**I spend most of my time working [on the examples](https://github.com/osmlab/osm-api-js/pull/33/changes#diff-cda206076cc366eb9297c40ac27e3b180426538ec5d257572aaf3b21ca70ae7d) to see they make sense to me and cover edge cases.**
The code and tests are generated an not reviewed by me, yet. — This will have to follow.
I also did not test the actual feature, yet. I was looking into setting up a /demo app that could be part of this repo which allows to use (a few) of the examples on the staging/production OSM server.

The main ideal of the change here is, that they replace the get/update/deletePreferences helper with new ones which allow to handle one key-value or split the values. They also add optional parsing/validation.

This means however, that the old APIs would be deprecated or removed. They are deprecated in this PR… except for `getPreferences` which I overwrote for a different purpose: Do get a list of all preferences for this user. So the current state is not ideal. I will either have to remove the two left over deprecations or remove the new function or rename the new function…

---

**So what is this draft about ATM:**
1. Lets talk about the examples to see I am on the right track here.
2. Would a /demo app be something for this repo? – Update https://github.com/osmlab/osm-api-js/pull/33#issuecomment-4414521572
3. How should I handle the deprecation / name conflict?
