### PR TITLE
[uploadChangeset] optionally handle merge conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [uploadChangeset] optionally handle merge conflicts, if you provide callback functions for `onAutomaticConflict` and `onManualConflict`.
+
 ## 4.0.0 (2026-02-11)
 
 - 💥 BREAKING CHANGE: `uploadChangeset` now returns a object instead of a single changeset ID. This is because:

--- a/examples/uploadChangeset.md
+++ b/examples/uploadChangeset.md
@@ -20,6 +20,8 @@ await uploadChangeset(
   {
     // optional callbacks and options, see below for details
     onChunk: () => {},
+    onAutomaticConflict: () => {},
+    onManualConflict: () => {},
   }
 );
 ```
@@ -121,6 +123,90 @@ await uploadChangeset(changesetTags, diff, {
 });
 ```
 
+### onAutomaticConflict
+
+When uploading a changeset, a [merge conflict](https://en.wikipedia.org/wiki/Edit_conflict) could occur if two users edit the same feature at the same time.
+
+When this happens, this library might be able to automatically resolve the conflict, if the conflict is simple enough.
+For example, if both users deleted the same feature, then that conflict will be automatically resolved by this library.
+
+When an merge conflict occurs that can be automatically resolved, the library will call a callback called `onAutomaticConflict`.
+
+The callback is invoked **for every conflicting feature**.
+
+- If there is no callback, `onManualConflict` will be called instead
+- If the callback returns `false`, then `onManualConflict` will be called instead
+- If the callback returns an object, then the upload continues.
+- You can optionally return an object of changeset `Tags`. If provided, then the changeset tags are updated to match the tags that you provided.
+
+> [!NOTE]
+> If you do not define `onAutomaticConflict` and do not define `onManualConflict` (see below),
+> then any merge conflict will cause `uploadChangeset` to throw an error.
+
+### onManualConflict
+
+Some conflicts are too complicated to be automatically resolved.
+
+For example, <kbd>you</kbd> add a tag to a feature at the same time that <kbd>other user</kbd> deletes the feature.
+
+In this case, your code needs to decide what do to. Options include:
+
+- keeping <kbd>you</kbd>r changes (the `local` version)
+- keeping <kbd>other user</kbd>'s changes (the `remote` version)
+- merging the changes automatically using your own logic.
+- prompting the user to compare the diff and select who's version should be kept.
+
+The `onManualConflict` callback is invoked if a merge conflict occurs while uploading, and that conflict is too complex to be resolved automatically by this library.
+
+The callback is invoked **for every conflicting feature**.
+
+- If there is no callback, then the upload fails.
+- If the callback returns `false`, then the upload fails.
+- If the callback returns a merged object, then that merged
+  object is used.
+  - You can directly return the `local` or `remote` version,
+    or merge the two yourself and return the merged version.
+  - You can also optionally return an object of changeset
+    `Tags`. If provided, then the changeset tags are updated
+    to match the tags that you provided.
+
+> [!NOTE]
+> If you do not define `onManualConflict` and do not define `onAutomaticConflict` (see above),
+> then any merge conflict will cause `uploadChangeset` to throw an error.
+
+## maxRetries
+
+If a merge conflict occurs between <kbd>you</kbd> and <kbd>other user</kbd>, it might take <kbd>you</kbd> several minutes to resolve the conflicts using your UI.
+During that time, <kbd>other user</kbd> might make more edits, and cause more conflicts.
+
+Example:
+
+```mermaid
+gitGraph
+    commit id: "v1"
+    branch local
+    checkout local
+    checkout main
+    commit id: "v2 (other user)"
+    checkout local
+    commit id: "v2 (you)"
+    merge main
+    checkout main
+    commit id: "v3 (other user)"
+    merge local
+```
+
+In this example graph, <kbd>you</kbd> and <kbd>other user</kbd> both created `v2`, which is a conflict.
+While <kbd>you</kbd> are resolving conflicts, <kbd>other user</kbd> has published `v3`.
+
+&nbsp;
+
+If this happens, the 2nd attempt to upload your changes will also fail.
+Conflict resolution will need to run again, then the library will try to upload your changes for the 3rd time.
+
+Although this case is extremely unlikely, it could theoretically continue on forever.
+The option `maxRetries` specifies how many times this should be retried. By default, it is set to `3`.
+
 ### onProgress
 
 `onProgress` is a callback function which is called whenever the upload progress changes.
@@ -135,3 +221,4 @@ It is called with an object parameter:
 ```
 
 `step` is a number from `0` to `total` which could be used to render a progress bar.
+total` might change during the upload, for example, if merge conflicts are encountered, and extra steps are required.

--- a/src/api/changesets/mergeConflict.ts
+++ b/src/api/changesets/mergeConflict.ts
@@ -1,0 +1,275 @@
+import type {
+  OsmChange,
+  OsmFeature,
+  OsmFeatureType,
+  Tags,
+  UtilFeatureForType,
+} from "../../types";
+import { osmFetch } from "../_osmFetch";
+import { getFeatures } from "../getFeature";
+import { createChangesetMetaXml } from "./_createOsmChangeXml";
+import type { UploadOptions } from "./uploadChangeset";
+
+/** @internal */
+type Features = {
+  [T in OsmFeatureType]?: { [id: number]: UtilFeatureForType<T> };
+};
+
+/** @internal */
+export function* chunkArray<T>(
+  array: T[],
+  limit: number
+): Generator<T[], void> {
+  for (let index = 0; index < array.length; index += limit) {
+    yield array.slice(index, index + limit);
+  }
+}
+
+/**
+ * @internal fetches the latest version of every feature from
+ * the API. Chunks the features into groups to reduce API requests.
+ */
+async function fetchChunked(
+  toFetch: Pick<OsmFeature, "type" | "id">[],
+  onProgress: (total: number) => void
+): Promise<Features> {
+  // group by type first.
+  const grouped: { [T in OsmFeatureType]?: Set<number> } = {};
+  for (const { type, id } of toFetch) {
+    grouped[type] ||= new Set();
+    grouped[type].add(id);
+  }
+
+  let totalFetched = 0;
+
+  const fetched: Features = {};
+  for (const _type in grouped) {
+    const type = <OsmFeatureType>_type;
+    const unchunked = grouped[type]!;
+    // fetch in chunks of 100
+    for (const ids of chunkArray([...unchunked], 100)) {
+      console.log(`Fetching ${ids.length} ${type}s...`);
+      const features = await getFeatures(type, ids);
+
+      for (const feature of features) {
+        fetched[type] ||= {};
+        fetched[type][feature.id] = feature;
+      }
+
+      totalFetched += features.length;
+      onProgress(totalFetched);
+    }
+  }
+  return fetched;
+}
+
+function tryAutoResolveConflict<T extends OsmFeature>(
+  remote: T,
+  local: T
+): T | undefined {
+  if (remote.visible === false && local.visible === false) {
+    // deleted on both the remote and the local. doesn't matter which one we keep.
+    return remote;
+  }
+
+  if (remote.visible !== local.visible) {
+    // deleted by one, but modified by the other.
+    // we definitely can't auto-resolve this.
+    return undefined;
+  }
+
+  const locDiff =
+    remote.type === "node" &&
+    local.type === "node" &&
+    (remote.lat !== local.lat || remote.lon !== local.lon);
+
+  const nodesDiff =
+    remote.type === "way" &&
+    local.type === "way" &&
+    remote.nodes.join(",") !== local.nodes.join(",");
+
+  const membersDiff =
+    remote.type === "relation" &&
+    local.type === "relation" &&
+    JSON.stringify(remote.members) !== JSON.stringify(local.members);
+
+  const intrinsicDiff = locDiff || nodesDiff || membersDiff;
+  if (intrinsicDiff) {
+    // there is a conflict between intrinsic attributes, we can't
+    // auto-resolve this.
+    return undefined;
+  }
+
+  const tagDiff = JSON.stringify(remote.tags) !== JSON.stringify(local.tags);
+  if (tagDiff) {
+    // tags are different. since we don't have access to the base version,
+    // we can't determine who added which tags. Therefore, we can't
+    // intelligently merge the remaining conflicts in this function.
+    return undefined;
+  }
+
+  // if we get to here, then the two versions are actually identical. So we
+  // can safely pick either local or remote.
+  return remote;
+}
+
+/** @internal */
+export async function handleMergeConflict({
+  csId,
+  csTags: originalCsTags,
+  chunk: originalChunk,
+  fetchOptions,
+  onProgress,
+  onAutomaticConflict,
+  onManualConflict,
+}: {
+  csId: number;
+  csTags: Tags;
+  chunk: OsmChange;
+  fetchOptions: RequestInit;
+  onProgress: UploadOptions["onProgress"];
+  onAutomaticConflict: UploadOptions["onAutomaticConflict"];
+  onManualConflict: UploadOptions["onManualConflict"];
+}) {
+  let csTags = { ...originalCsTags };
+  const chunk = structuredClone(originalChunk);
+
+  let didAutoResolve = csTags["merge_conflict_resolved"]
+    ?.split(";")
+    .includes("automatically");
+  let didManualResolve = csTags["merge_conflict_resolved"]
+    ?.split(";")
+    .includes("manually");
+
+  // anything that was modified or deleting could have caused a conflict,
+  // so we need to fetch the latest version for each feature.
+  const potentiallyConflicting = [...chunk.modify, ...chunk.delete];
+
+  onProgress?.({
+    phase: "merge_conflicts",
+    step: 0,
+    total: potentiallyConflicting.length * 2,
+  });
+
+  const remoteVersions = await fetchChunked(potentiallyConflicting, (count) => {
+    onProgress?.({
+      phase: "merge_conflicts",
+      step: count,
+      total: potentiallyConflicting.length * 2,
+    });
+  });
+
+  // loop through everything in the OsmChange
+  let countChecked = 0;
+  for (const _action in chunk) {
+    const action = <keyof OsmChange>_action;
+
+    // newly created elements can't have conflicts
+    if (action === "create") continue;
+
+    for (const [index, local] of chunk[action].entries()) {
+      countChecked++;
+      onProgress?.({
+        phase: "merge_conflicts",
+        step: potentiallyConflicting.length + countChecked,
+        total: potentiallyConflicting.length * 2,
+      });
+
+      const remote = remoteVersions[local.type]?.[local.id];
+      // for every updated+deleted feature, check if our local version
+      // has the same version as the latest remote version.
+
+      if (!remote) continue; // skip if the API somehow didn't return this feature
+      if (remote.version === local.version) continue; // skip if no conflict
+
+      const diffId = `${local.type[0]}${local.id}@(${local.version}…${remote.version})`;
+
+      // try to automatically resolve conflicts:
+      const autoMerged = tryAutoResolveConflict(remote, local);
+
+      let merged: { tags?: Tags; merged: OsmFeature };
+      if (autoMerged && onAutomaticConflict) {
+        // we were able to auto-resolve the conflicts,
+        // call the user's onAutomaticConflict callback.
+        const result = await onAutomaticConflict?.({
+          remote,
+          local,
+          merged: autoMerged,
+        });
+        if (!result) {
+          throw new Error(
+            `A merge conflict occured, but onAutomaticConflict returned false for ${diffId}`
+          );
+        }
+
+        didAutoResolve = true;
+        merged = { ...result, merged: autoMerged };
+      } else {
+        // else: we were not able to auto-resolve the conflicts, because
+        // they are too complicated (OR: because the user didn't specify
+        // an onAutomaticConflict callback)
+        if (!onManualConflict) {
+          throw new Error(
+            autoMerged
+              ? `A auto-mergable conflict occured for ${diffId}, but neither onAutomaticConflict nor onManualConflict is not defined.`
+              : `A complex merge conflict occured for ${diffId}, but onManualConflict is not defined.`
+          );
+        }
+
+        const result = await onManualConflict?.({ remote, local });
+        if (result === false) {
+          throw new Error(
+            `A merge conflict occured, but onManualConflict returned false for ${diffId}`
+          );
+        }
+
+        didManualResolve = true;
+        merged = result;
+      }
+
+      // this code runs regardless of manual or automatic
+
+      if (merged.tags) {
+        // the user wants to update the changeset tags
+        const originalTags = csTags;
+        csTags = merged.tags;
+
+        // if the user forgot to include created_by, add it back.
+        // this tag is required.
+        csTags["created_by"] ||= originalTags["created_by"];
+
+        // preserve this tag which might have been added earlier in
+        // the process. cannot be overriden by users.
+        if (originalTags["chunk"]) csTags["chunk"] = originalTags["chunk"];
+      }
+
+      // replace this feature in the osmChange with
+      // the merged version, and bump the version.
+      merged.merged.version = remote.version;
+      chunk[action][index] = merged.merged;
+    }
+
+    // this tag is always added, consumers can't remove it, similar to `created_by`.
+    if (didAutoResolve && didManualResolve) {
+      csTags["merge_conflict_resolved"] = "automatically;manually";
+    } else if (didAutoResolve) {
+      csTags["merge_conflict_resolved"] = "automatically";
+    } else if (didManualResolve) {
+      csTags["merge_conflict_resolved"] = "manually";
+    }
+  }
+
+  // update changeset tags to include `merge_conflict_resolved` + any custom tags
+  // TODO: what is the API response? does it matter?
+  await osmFetch(`/0.6/changeset/${csId}`, undefined, {
+    ...fetchOptions,
+    method: "PUT",
+    body: createChangesetMetaXml(csTags),
+    headers: {
+      ...fetchOptions.headers,
+      "content-type": "application/xml; charset=utf-8",
+    },
+  });
+
+  return { csTags, chunk };
+}

--- a/src/api/changesets/uploadChangeset.ts
+++ b/src/api/changesets/uploadChangeset.ts
@@ -1,4 +1,4 @@
-import type { OsmChange, OsmFeatureType, Tags } from "../../types";
+import type { OsmChange, OsmFeature, OsmFeatureType, Tags } from "../../types";
 import { type FetchOptions, osmFetch } from "../_osmFetch";
 import { version } from "../../../package.json";
 import type { RawUploadResponse } from "../_rawResponse";
@@ -7,6 +7,7 @@ import {
   createOsmChangeXml,
 } from "./_createOsmChangeXml";
 import { chunkOsmChange, getOsmChangeSize } from "./chunkOsmChange";
+import { handleMergeConflict } from "./mergeConflict";
 
 export interface UploadChunkInfo {
   /** the total number of features being uploaded (counting all chunks) */
@@ -16,6 +17,22 @@ export interface UploadChunkInfo {
   changesetIndex: number;
   /** the number of changesets required for this upload */
   changesetTotal: number;
+}
+
+export interface AutoConflictInfo<T extends OsmFeature = OsmFeature> {
+  /** the latest version from the user's side (the version that the user tried to upload) */
+  local: T;
+  /** the latest version on the remote server */
+  remote: T;
+  /** the result of automatically merging the `local` and `remote` version */
+  merged: T;
+}
+
+export interface ManualConflictInfo<T extends OsmFeature = OsmFeature> {
+  /** the latest version from the user's side (the version that the user tried to upload) */
+  local: T;
+  /** the latest version on the remote server */
+  remote: T;
 }
 
 export type UploadPhase = "upload" | "merge_conflicts";
@@ -64,6 +81,55 @@ export interface UploadOptions {
     total: number;
   }): void;
 
+  /**
+   * This callback is invoked if a merge conflict occurs while
+   * uploading, and that conflict is simple enough to be
+   * automatically resolved this library.
+   *
+   * The callback is invoked **for every conflicting feature**.
+   *
+   *  - If there is no callback, `onManualConflict` will be called instead
+   *  - If the callback returns `false`, then `onManualConflict` will be called instead
+   *  - If the callback returns an object, then the upload continues.
+   *    - You can optionally return an object of changeset
+   *      `Tags`. If provided, then the changeset tags are updated
+   *      to match the tags that you provided.
+   */
+  onAutomaticConflict?(
+    info: AutoConflictInfo
+  ): { tags?: Tags } | false | Promise<{ tags?: Tags } | false>;
+
+  /**
+   * This callback is invoked if a merge conflict occurs while
+   * uploading, and that conflict is too complex to be resolved
+   * automatically by this library.
+   *
+   * The callback is invoked **for every conflicting feature**.
+   *
+   *  - If there is no callback, then the upload fails.
+   *  - If the callback returns `false`, then the upload fails.
+   *  - If the callback returns a merged object, then that merged
+   *    object is used.
+   *    - You can directly return the `local` or `remote` version,
+   *      or merge the two yourself and return the merged version.
+   *    - You can also optionally return an object of changeset
+   *      `Tags`. If provided, then the changeset tags are updated
+   *      to match the tags that you provided.
+   */
+  onManualConflict?(
+    info: ManualConflictInfo
+  ):
+    | { tags?: Tags; merged: OsmFeature }
+    | false
+    | Promise<{ tags?: Tags; merged: OsmFeature } | false>;
+
+  /**
+   * If a merge conflict occurs, this is the number of times that
+   * the upload should be retried.
+   * @default 5
+   */
+  maxRetries?: number;
+
   /** by default, uploads are compressed with gzip. set to `false` to disable */
   disableCompression?: boolean;
 }
@@ -80,8 +146,10 @@ export async function uploadChangeset(
   const {
     onChunk,
     onProgress,
+    onAutomaticConflict,
+    onManualConflict,
+    maxRetries = 3,
     disableCompression,
-    //
     ...fetchOptions
   } = options || {};
 
@@ -90,7 +158,7 @@ export async function uploadChangeset(
 
   const result: UploadResult = {};
 
-  for (const [index, chunk] of chunks.entries()) {
+  for (const [index, _chunk] of chunks.entries()) {
     let tagsForChunk = tags;
 
     // if this is a chunk of an enourmous changeset, the tags
@@ -113,7 +181,7 @@ export async function uploadChangeset(
     // if the user didn't include a `created_by` tag, we'll add one.
     tagsForChunk["created_by"] ||= `osm-api-js ${version}`;
 
-    onProgress?.({ phase: "upload", step: index + 1, total: chunks.length });
+    onProgress?.({ phase: "upload", step: index, total: chunks.length });
 
     const csId = +(await osmFetch<string>("/0.6/changeset/create", undefined, {
       ...fetchOptions,
@@ -125,40 +193,93 @@ export async function uploadChangeset(
       },
     }));
 
-    const osmChangeXml = createOsmChangeXml(csId, chunk);
-
-    const compressed = !disableCompression && (await compress(osmChangeXml));
-
-    const idMap = await osmFetch<RawUploadResponse>(
-      `/0.6/changeset/${csId}/upload`,
-      undefined,
-      {
-        ...fetchOptions,
-        method: "POST",
-        body: compressed || osmChangeXml,
-        headers: {
-          ...fetchOptions.headers,
-          ...(compressed && { "Content-Encoding": "gzip" }),
-          "content-type": "application/xml; charset=utf-8",
-        },
+    let csTags = tagsForChunk;
+    let chunk = _chunk;
+    let retryIndex = 0;
+    while (true) {
+      if (retryIndex++ === maxRetries) {
+        throw new Error(
+          `Merge conflicts could not be resolved after ${maxRetries} retries`
+        );
       }
-    );
 
-    // convert the XML format into a more concise JSON format
-    result[csId] = { diffResult: {} };
-    for (const _type in idMap.diffResult[0]) {
-      if (_type === "$") continue;
-      const type = <OsmFeatureType>_type;
-      const items = idMap.diffResult[0][type] || [];
-      for (const item of items) {
-        result[csId].diffResult[type] ||= {};
-        result[csId].diffResult[type][item.$.old_id] = {
-          newId: +item.$.new_id,
-          newVersion: +item.$.new_version,
-        };
+      onProgress?.({
+        phase: "upload",
+        step: index + retryIndex / maxRetries,
+        total: chunks.length,
+      });
+
+      try {
+        const osmChangeXml = createOsmChangeXml(csId, chunk);
+
+        const compressed =
+          !disableCompression && (await compress(osmChangeXml));
+
+        const idMap = await osmFetch<RawUploadResponse>(
+          `/0.6/changeset/${csId}/upload`,
+          undefined,
+          {
+            ...fetchOptions,
+            method: "POST",
+            body: compressed || osmChangeXml,
+            headers: {
+              ...fetchOptions.headers,
+              ...(compressed && { "Content-Encoding": "gzip" }),
+              "content-type": "application/xml; charset=utf-8",
+            },
+          }
+        );
+
+        // convert the XML format into a more concise JSON format
+        result[csId] = { diffResult: {} };
+        for (const _type in idMap.diffResult[0]) {
+          if (_type === "$") continue;
+          const type = <OsmFeatureType>_type;
+          const items = idMap.diffResult[0][type] || [];
+          for (const item of items) {
+            result[csId].diffResult[type] ||= {};
+            result[csId].diffResult[type][item.$.old_id] = {
+              newId: +item.$.new_id,
+              newVersion: +item.$.new_version,
+            };
+          }
+        }
+        break;
+      } catch (error) {
+        if (error instanceof Error && error.cause === 409) {
+          // There is a merge conflict
+          try {
+            ({ csTags, chunk } = await handleMergeConflict({
+              csId,
+              csTags,
+              chunk,
+              fetchOptions,
+              onProgress,
+              onAutomaticConflict,
+              onManualConflict,
+            }));
+            // loop again
+          } catch (_conflictError) {
+            // throw the error from handleMergeConflict linked
+            // to the original 409 error from the API.
+            const conflictError =
+              _conflictError instanceof Error
+                ? _conflictError
+                : new Error(`${_conflictError}`);
+            conflictError.cause = error;
+            throw conflictError;
+          }
+        } else {
+          throw error; // any other error
+        }
       }
     }
 
+    // if this request fails, the user shouldn't retry the upload, because uploading
+    // has already suceeded at this point, we just couldn't close the changeset.
+    // See https://github.com/openstreetmap/iD/issues/2667#issuecomment-108068071
+    // TODO: handle this better. Could the thrown error have a property to indicate
+    // whether at what phase the upload failed?
     await osmFetch(`/0.6/changeset/${csId}/close`, undefined, {
       ...fetchOptions,
       method: "PUT",

--- a/taginfo.json
+++ b/taginfo.json
@@ -16,6 +16,21 @@
     {
       "key": "chunk",
       "description": "Added to changesets when uploading, if the changeset was so big that it had to be chunked (split) into multiple changesets."
+    },
+    {
+      "key": "merge_conflict_resolved",
+      "value": "automatically",
+      "description": "Added to changesets if a merge conflict occured and it was automatically resolved (without user interaction)."
+    },
+    {
+      "key": "merge_conflict_resolved",
+      "value": "manually",
+      "description": "Added to changesets if a merge conflict occured and it was manually resolved by the user."
+    },
+    {
+      "key": "merge_conflict_resolved",
+      "value": "automatically;manually",
+      "description": "Added to changesets if multiple merge conflicts occured, and some were automatically resolved and others were manually resolved."
     }
   ]
 }


### PR DESCRIPTION
lots of logic and unit tests so that consumers don't have to worry about the intricacies of merge conflicts. see [the updated documentation](https://github.com/osmlab/osm-api-js/blob/db5276e30f5a7888963c496f44a1f72039b3da0f/examples/uploadChangeset.md#onautomaticconflict) for details.